### PR TITLE
remote eval demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,22 @@ help:
 
 release: lint typecheck test build upload
 	@echo "Published to PyPI"
+
+# Demo for Remote Evaluation using Serveo.net
+demo-remote-eval:
+	@echo "---------------------------------------------------------------------"
+	@echo "Running Remote Evaluation Demo with Serveo.net..."
+	@echo "This demo will:"
+	@echo "1. Generate a temporary API key."
+	@echo "2. Start a local mock API service."
+	@echo "3. Expose the mock API service to the internet using Serveo.net via SSH."
+	@echo "   (Requires a working SSH client in your PATH)"
+	@echo "4. Run evaluation functions that call the tunneled mock API service."
+	@echo "5. Clean up all started processes on completion or interruption."
+	@echo "---------------------------------------------------------------------"
+	@echo "Log files for the demo will be created in ./logs/remote_eval_demo/"
+	@echo "Starting demo script..."
+	python examples/remote_eval_demo/run_demo.py
+	@echo "---------------------------------------------------------------------"
+	@echo "Remote Evaluation Demo finished."
+	@echo "---------------------------------------------------------------------"

--- a/development/DEMO_READINESS.md
+++ b/development/DEMO_READINESS.md
@@ -95,6 +95,7 @@ graph TD
 *   [Coding Example](./readiness/coding_example.md)
 *   [Function Calling Example](./readiness/function_calling_example.md)
 *   [Composite Example (Math + Coding)](./readiness/composite_math_coding_example.md)
+*   [Remote Evaluation with Secrets and Ngrok](./readiness/remote_evaluation_setup_plan.md)
 
 ---
 

--- a/development/readiness/remote_evaluation_setup_plan.md
+++ b/development/readiness/remote_evaluation_setup_plan.md
@@ -1,0 +1,171 @@
+# Plan: Remote Evaluation with Secrets (Automated Tunneling via Serveo.net)
+
+This document outlines the plan to set up a demonstration for remote evaluation capabilities. The demo will focus on using environment variables and the `fireworks secret` mechanism for managing secrets required by evaluation functions that invoke remote URLs. For achieving a one-command, automated demo, **Serveo.net** will be used for exposing the local mock server, prioritizing minimal external dependencies (assuming a standard SSH client). Initial manual setup steps might still reference Ngrok or other tunneling tools as manual alternatives for developer testing.
+
+## 1. Objectives
+
+*   Demonstrate that evaluation functions can call arbitrary remote URLs.
+*   Showcase secure secret management for API keys using `fireworks secret`.
+*   Illustrate a less secure method (hardcoding) for comparison.
+*   Provide a utility for API key generation.
+*   Adapt an existing simple reward function (e.g., math reward) to fit this scenario for local testing.
+*   **Key Goal for Automation:** Enable a one-command execution (e.g., `make demo-remote-eval`) that sets up all necessary components, including the public tunnel, using Serveo.net.
+
+## 2. Components
+
+### 2.1. Mock API Service (FastAPI) - **Status: DONE**
+*   **Purpose:** Simulate an external service requiring API key authentication.
+*   **Technology:** Python with FastAPI.
+*   **Endpoint:** A simple endpoint (e.g., `/api/validate_data`).
+    *   Accepts: A small JSON payload.
+    *   Requires: An API key passed in a custom header (e.g., `X-Secret-API-Key`).
+*   **Behavior:** Validates the API key. If valid, processes the payload and returns a success message. If invalid, returns an authentication error.
+
+### 2.2. Tunneling Component (Targeting Serveo.net for Automation)
+*   **Purpose:** Expose the local FastAPI service to the public internet, making it accessible as a remote URL.
+*   **Automated Tool (Target for `make demo-remote-eval`):** Serveo.net (using SSH). - **Status: Implementation TODO (See Section 6)**
+*   **Manual Alternatives (For developer testing of components):** Ngrok, Localtunnel can be used if preferred by the developer during initial component development, but the final automated demo script will integrate Serveo.net.
+*   **Setup (Serveo.net):** Relies on a standard SSH client. The demo script will automate the `ssh -R ... serveo.net` command.
+
+### 2.3. Evaluation Function (`remote_validator_reward`) - **Status: DONE**
+*   **Purpose:** A Python function, decorated with `@reward_function`, that calls the tunneled FastAPI service.
+*   **Logic:**
+    1.  Accepts input parameters.
+    2.  Retrieves the API key for the mock service.
+    3.  Constructs and sends an HTTP request to the mock API's endpoint (via the tunnel URL).
+    4.  Includes the API key in the `X-Secret-API-Key` header.
+    5.  Evaluates the response from the mock API.
+*   **Note:** Variable names for tunnel URL (e.g., `DEFAULT_NGROK_URL`) in existing reward functions may need generalization (e.g., to `DEFAULT_TUNNEL_URL`).
+
+### 2.4. Secret Management Strategies - **Status: Implemented in Reward Functions**
+*   **Strategy A: Hardcoded Secret** - **Status: DONE**
+*   **Strategy B: `fireworks secret` Integration (Simulated via Env Var)** - **Status: DONE**
+
+## 3. Detailed Implementation Steps
+
+**Current Status of Overall Plan (as of YYYY-MM-DD - *developer to fill in date*):**
+*   **Core Components (Steps 1, 2, 4, 5 below):** The API key generator, mock FastAPI service, and the two reward function variants (hardcoded and secure via env var) have been implemented. These components are designed to work with a generic tunnel URL.
+*   **Automated Demo Script (`run_demo.py`, `subprocess_manager.py`, `Makefile`):** An initial version targeting Ngrok automation was developed. **This is now being redirected to use Serveo.net.** The existing automation code provides a base but requires significant modification/replacement for Serveo (see Section 6).
+*   **Documentation (`README.md` for demo, this plan):** Initial versions exist, need updates to reflect the Serveo strategy.
+
+The following steps describe the creation of the core components. The automation of these components into a one-command demo using Serveo.net is detailed in Section 6.
+
+### Step 1: Develop Utility for API Key Generation - **Status: DONE**
+*   Create `generate_api_key.py` in `development/utils/`.
+*   Implement a function using `secrets.token_hex()` or `uuid.uuid4()`.
+*   Provide a simple CLI interface.
+
+### Step 2: Develop the FastAPI Mock Service - **Status: DONE**
+*   Create `mock_api_service.py` in `examples/remote_eval_demo/`.
+*   Implement the FastAPI app with the `/api/validate_data` endpoint.
+*   Store the "expected" API key (e.g., from Step 1, or a consistent demo key).
+*   Document how to run it manually (e.g., `python examples/remote_eval_demo/mock_api_service.py` or `uvicorn ...`).
+
+### Step 3: Tunneling Setup and Configuration - **Status: Manual options documented; Automation via Serveo is TODO (See Section 6)**
+*   **For Automated Demo (Target: Serveo.net):** This step will be handled automatically by the `run_demo.py` script using Serveo.net. No manual ngrok/localtunnel setup is required by the end-user running `make demo-remote-eval`. (See Section 6 for automation details).
+*   **For Manual Component Testing (Developer-Only):**
+    *   If a developer is testing components individually, they can manually use any tunneling tool:
+        *   **Serveo.net (manual):** `ssh -R 80:localhost:8001 serveo.net` (copy the HTTPS URL).
+        *   **Ngrok (manual):** Install ngrok, then `ngrok http 8001` (copy the HTTPS URL).
+        *   **Localtunnel (manual):** `npm install -g localtunnel`, then `lt --port 8001` (copy the URL).
+    *   The evaluation functions will need their tunnel URL constant updated with the manually obtained URL for such tests. The automated `run_demo.py` will pass this URL programmatically.
+
+### Step 4: Implement Evaluation Function - Strategy A (Hardcoded Secret) - **Status: DONE**
+*   Create `remote_validator_reward_hardcoded.py` in `examples/remote_eval_demo/rewards/`.
+*   Implement the reward function, hardcoding the tunnel URL (e.g. `DEFAULT_TUNNEL_URL` - to be updated by `run_demo.py` or manually for tests) and API key.
+*   **Note:** Existing file uses `HARDCODED_NGROK_URL`; consider renaming for generality.
+
+### Step 5: Implement Evaluation Function - Strategy B (`fireworks secret` via Env Var) - **Status: DONE**
+*   Create `remote_validator_reward_secure.py` in `examples/remote_eval_demo/rewards/`.
+*   Modify the function to retrieve the API key using `os.getenv("MOCK_SERVICE_API_KEY")`.
+*   Tunnel URL handled similarly to Strategy A.
+*   **Note:** Existing file uses `DEFAULT_NGROK_URL`; consider renaming.
+
+### Step 6: Documentation and Demo Script (Initial Local Runner) - **Status: Partially DONE (`run_demo.py` needs Serveo integration, `README.md` needs Serveo focus)**
+*   Update `development/DEMO_READINESS.md` with a section for this demo. - **Status: DONE** (Link added)
+*   The `run_demo.py` script (for local execution) has been created. It currently includes logic for Ngrok automation which needs to be **replaced with Serveo automation** (see Section 6).
+*   The final user-facing documentation in `examples/remote_eval_demo/README.md` needs to be **updated for Serveo**.
+
+## 4. Files to Create/Modify (Reflecting Serveo Automation Goal)
+
+*   `development/readiness/remote_evaluation_setup_plan.md` (This file) - **Status: BEING UPDATED NOW**
+*   `development/utils/generate_api_key.py` - **Status: DONE**
+*   `examples/remote_eval_demo/mock_api_service.py` - **Status: DONE**
+*   `examples/remote_eval_demo/rewards/remote_validator_reward_hardcoded.py` - **Status: DONE** (Consider renaming URL const)
+*   `examples/remote_eval_demo/rewards/remote_validator_reward_secure.py` - **Status: DONE** (Consider renaming URL const)
+*   `examples/remote_eval_demo/run_demo.py` - **Status: Partially DONE (Ngrok base), NEEDS SERVEO IMPL.**
+*   `development/utils/subprocess_manager.py` - **Status: Partially DONE (Ngrok base), NEEDS SERVEO IMPL. & Ngrok code removal/deprecation.**
+*   `Makefile` (Update) - **Status: Partially DONE (Ngrok base), NEEDS SERVEO IMPL.**
+*   `examples/remote_eval_demo/README.md` (New) - **Status: Partially DONE (Ngrok base), NEEDS SERVEO IMPL.**
+*   `development/DEMO_READINESS.md` (Update) - **Status: DONE** (Link added)
+
+## 5. Considerations (General)
+
+*   **Error Handling:** Reward functions and demo scripts should handle network errors, API errors, missing secrets, and tunnel failures gracefully. - **Status: Basic handling in place, review for robustness.**
+*   **Idempotency:** Mock API is read-only for the demo endpoint. - **Status: OK**
+*   **Clarity:** Demo should distinguish local execution vs. platform. - **Status: OK**
+*   **Reward Kit Version:** Ensure compatibility. - **Status: OK**
+
+## 6. Automating Tunneling for One-Command Demo using Serveo.net
+
+**Overall Goal:** Achieve a true one-command demo (e.g., via a `make` target) by automating the use of **Serveo.net** for exposing the local mock server. This choice prioritizes minimizing additional software installations for the user, assuming a standard SSH client is available.
+
+**Current Status of this Section (as of YYYY-MM-DD - *developer to fill in date*):**
+*   **Previous Ngrok Automation Attempt (To be Replaced):**
+    *   An initial attempt was made to automate tunneling using Ngrok. This involved changes to `development/utils/subprocess_manager.py`, `examples/remote_eval_demo/run_demo.py`, and `Makefile`.
+    *   **Decision:** This Ngrok-based automation will be **replaced** by a Serveo.net implementation to better meet the goal of minimal external dependencies. The existing Ngrok-specific code in `subprocess_manager.py` (`start_ngrok_and_get_url`, `get_ngrok_public_url`) should be removed or clearly marked as deprecated/archived if kept for reference.
+*   **Serveo.net Implementation (Not Started - THIS IS THE NEXT STEP):**
+    *   The specific code changes for Serveo.net automation in `subprocess_manager.py` and `run_demo.py` have **not** been implemented. This is the primary task for the next developer.
+
+This section outlines the implementation path for using Serveo.net.
+
+### 6.1. Implementation Path for Serveo.net
+
+#### 6.1.1. Key Characteristics of Serveo.net
+*   **Pros:** Uses SSH, so no *additional* client software installation is typically needed if an SSH client is already present on the user's system. No registration is required for basic public tunnel use.
+*   **Cons:** The reliability of the public `serveo.net` service can vary. Automating SSH interactions (especially initial host key verification and parsing output for the URL) from a script can be more complex than tools with dedicated local APIs (like Ngrok).
+*   **Command Example:** `ssh -R 80:localhost:<local_port> serveo.net`
+
+#### 6.1.2. Required Changes in `development/utils/subprocess_manager.py` - **Status: TODO**
+*   **Task:** Create a new function `start_serveo_and_get_url(local_port: int, log_file_path: str) -> tuple[subprocess.Popen | None, str | None]:`
+    1.  **Check SSH Availability:** Verify that the `ssh` command is available on the system's PATH. If not, raise an error or return `(None, None)` with a clear message.
+    2.  **Construct SSH Command:**
+        *   The command should be similar to: `['ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', '-R', f'80:localhost:{local_port}', 'serveo.net']`.
+        *   The options `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null` are crucial for non-interactive execution. Note: `/dev/null` might need platform-specific handling (e.g., `nul` on Windows) or use of a temporary file.
+    3.  **Execute SSH Command:** Use `start_process` or `subprocess.Popen` directly, ensuring output (stdout/stderr) is captured for parsing.
+    4.  **Parse Output for URL:** Continuously read output, looking for `Forwarding HTTP traffic from https://<subdomain>.serveo.net`. Extract URL using regex.
+    5.  **Retry Logic & Timeout:** Implement a loop (e.g., 10-15 seconds) to find the URL. If not found, terminate SSH and return `(None, None)`.
+    6.  **Process Management:** Ensure the started `ssh` process is managed for cleanup.
+    7.  **Return Value:** `(ssh_process_object, public_url)` or `(None, None)`.
+*   **Task:** Remove or clearly deprecate existing Ngrok-specific functions (`start_ngrok_and_get_url`, `get_ngrok_public_url`).
+
+#### 6.1.3. Required Changes in `examples/remote_eval_demo/run_demo.py` - **Status: TODO**
+*   **Task:** Modify the script to use Serveo automation:
+    1.  Import `start_serveo_and_get_url`.
+    2.  Remove Ngrok-related calls and logic.
+    3.  Call `start_serveo_and_get_url`, handle success/failure.
+    4.  Assign fetched URL to a generic variable (e.g., `TUNNEL_PUBLIC_URL`) and pass to reward functions.
+    5.  Remove manual ngrok prompts.
+    6.  Ensure `atexit` handler stops the Serveo SSH process.
+
+#### 6.1.4. Required Changes in `Makefile` - **Status: TODO**
+*   **Task:** Update `demo-remote-eval` target description:
+    *   State it uses Serveo.net.
+    *   Prerequisite: "Working SSH client in PATH."
+    *   Remove Ngrok-specific notes.
+
+#### 6.1.5. Required Changes in `examples/remote_eval_demo/README.md` - **Status: TODO**
+*   **Task:** Overhaul README for Serveo:
+    1.  Update title, introduction.
+    2.  Prerequisites: Focus on SSH client. Remove Ngrok.
+    3.  "Running the Demo", "How it Works": Describe Serveo-based process.
+    4.  "Troubleshooting": Address common Serveo/SSH issues.
+
+### 6.2. Testing Focus for Serveo Implementation - **Status: TODO**
+*   **Cross-Platform:** Test SSH command and parsing on macOS, Linux, Windows.
+*   **First-Time Connection:** Verify non-interactive host key handling.
+*   **URL Parsing:** Ensure regex robustness.
+*   **Process Cleanup:** Confirm reliable termination of `ssh` tunnel.
+*   **Serveo Service Reliability:** Test with potential service flakiness in mind.
+
+This revised plan provides a more direct path for the next engineer to implement the Serveo.net solution for the one-command demo.

--- a/development/utils/generate_api_key.py
+++ b/development/utils/generate_api_key.py
@@ -1,0 +1,29 @@
+import secrets
+import argparse
+
+def generate_api_key(length: int = 32) -> str:
+    """
+    Generates a cryptographically strong random string to be used as an API key.
+
+    Args:
+        length: The desired length of the API key in bytes.
+                The resulting hex string will be twice this length.
+                Default is 32 bytes, resulting in a 64-character hex string.
+
+    Returns:
+        A hex-encoded secure random string.
+    """
+    return secrets.token_hex(length)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a secure API key.")
+    parser.add_argument(
+        "--length",
+        type=int,
+        default=32,
+        help="Length of the key in bytes (default: 32, produces a 64-char hex string)."
+    )
+    args = parser.parse_args()
+
+    api_key = generate_api_key(args.length)
+    print(api_key)

--- a/development/utils/subprocess_manager.py
+++ b/development/utils/subprocess_manager.py
@@ -1,0 +1,363 @@
+import subprocess
+import os
+import signal
+import time
+import json
+import re # Added for Serveo URL parsing
+import shutil # Added for checking ssh availability
+
+try:
+    import requests
+    REQUESTS_AVAILABLE = True
+except ImportError:
+    REQUESTS_AVAILABLE = False
+
+# Store PIDs of started processes
+managed_processes = {} # pid -> {process, command, log_file, log_file_path, env}
+
+# NGROK_API_URL = "http://127.0.0.1:4040/api/tunnels" # Deprecated
+
+def start_process(command: list, log_file_path: str, cwd: str = None, new_process_group: bool = True, env: dict | None = None) -> subprocess.Popen | None:
+    """
+    Starts a process in the background and logs its output.
+    Stores the process information for later management.
+
+    Args:
+        command: A list representing the command and its arguments.
+        log_file_path: Path to the file where stdout and stderr will be logged.
+        cwd: The working directory for the command. Defaults to current directory.
+        new_process_group: Whether to start the process in a new group (for Unix-like systems).
+        env: Optional dictionary of environment variables for the new process.
+
+    Returns:
+        The Popen object for the started process.
+    """
+    print(f"Starting process: {' '.join(command)}")
+    print(f"Logging output to: {log_file_path}")
+    
+    # Ensure log directory exists
+    os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+    
+    log_file = open(log_file_path, 'w')
+    
+    process_env = os.environ.copy()
+    if env:
+        process_env.update(env)
+
+    process = subprocess.Popen(
+        command,
+        stdout=log_file,
+        stderr=log_file,
+        cwd=cwd if cwd else os.getcwd(),
+        preexec_fn=os.setsid if (os.name != "nt" and new_process_group) else None,
+        env=process_env
+    )
+    
+    managed_processes[process.pid] = {
+        "process": process,
+        "command": command,
+        "log_file": log_file,
+        "log_file_path": log_file_path,
+        "is_ngrok": "ngrok" in command[0], # Basic check if it's an ngrok process
+        "env": env # Store the custom env variables passed
+    }
+    print(f"Process started with PID: {process.pid}")
+    return process
+
+# --- Ngrok functions (Deprecated in favor of Serveo) ---
+# def get_ngrok_public_url(retries=5, delay=3) -> str | None:
+#     """
+#     DEPRECATED: Use Serveo.net instead.
+#     Queries the local ngrok API to get the public HTTPS URL.
+#     """
+#     print("WARNING: get_ngrok_public_url is deprecated. Use Serveo.net based functions.")
+#     if not REQUESTS_AVAILABLE:
+#         print("ERROR: 'requests' library is not installed. Cannot fetch ngrok URL automatically.")
+#         return None
+#     global NGROK_API_URL # Ensure it's defined if this function were to be uncommented
+#     NGROK_API_URL = "http://127.0.0.1:4040/api/tunnels"
+
+
+#     for attempt in range(retries):
+#         try:
+#             response = requests.get(NGROK_API_URL, timeout=5)
+#             response.raise_for_status()
+#             tunnels_data = response.json()
+#             for tunnel in tunnels_data.get("tunnels", []):
+#                 if tunnel.get("proto") == "https" and tunnel.get("public_url", "").startswith("https://"):
+#                     print(f"Found ngrok public URL: {tunnel['public_url']}")
+#                     return tunnel["public_url"]
+#             print(f"Attempt {attempt + 1}/{retries}: HTTPS tunnel not found yet in ngrok API response. Retrying in {delay}s...")
+#         except requests.exceptions.ConnectionError:
+#             print(f"Attempt {attempt + 1}/{retries}: ngrok API not yet available at {NGROK_API_URL}. Retrying in {delay}s...")
+#         except Exception as e:
+#             print(f"Attempt {attempt + 1}/{retries}: Error fetching ngrok URL: {e}. Retrying in {delay}s...")
+#         time.sleep(delay)
+#     print("ERROR: Failed to get ngrok public URL after multiple retries.")
+#     return None
+
+# def start_ngrok_and_get_url(local_port: int, ngrok_log_file: str, authtoken: str = None) -> tuple[subprocess.Popen | None, str | None]:
+#     """
+#     DEPRECATED: Use Serveo.net instead.
+#     Starts ngrok to expose a local port and retrieves its public HTTPS URL.
+#     """
+#     print("WARNING: start_ngrok_and_get_url is deprecated. Use Serveo.net based functions.")
+#     ngrok_command = ["ngrok", "http", str(local_port), "--log=stdout"]
+    
+#     try:
+#         subprocess.run(["ngrok", "--version"], capture_output=True, check=True)
+#     except (subprocess.CalledProcessError, FileNotFoundError):
+#         print("ERROR: ngrok command not found or not executable. Please ensure ngrok is installed and in your PATH.")
+#         return None, None
+
+#     if authtoken:
+#         print(f"Note: Ngrok authtoken should be pre-configured by the user via 'ngrok config add-authtoken <token>'.")
+
+#     print(f"Attempting to start ngrok for port {local_port}...")
+#     ngrok_process = start_process(ngrok_command, ngrok_log_file, new_process_group=False)
+
+#     if not ngrok_process or ngrok_process.poll() is not None:
+#         print(f"ERROR: Failed to start ngrok. Check log: {ngrok_log_file}")
+#         if ngrok_process and ngrok_process.pid in managed_processes:
+#             stop_process(ngrok_process.pid)
+#         return None, None
+    
+#     print(f"ngrok process started with PID {ngrok_process.pid}. Waiting for tunnel...")
+#     time.sleep(8) 
+
+#     public_url = get_ngrok_public_url()
+
+#     if not public_url:
+#         print("ERROR: Could not retrieve public URL from ngrok.")
+#         stop_process(ngrok_process.pid)
+#         return None, None
+    
+#     return ngrok_process, public_url
+# --- End of Deprecated Ngrok functions ---
+
+def start_serveo_and_get_url(local_port: int, log_file_path: str, timeout_seconds: int = 20) -> tuple[subprocess.Popen | None, str | None]:
+    """
+    Starts Serveo.net SSH tunnel to expose a local port and retrieves its public HTTPS URL.
+    The SSH process is added to managed_processes.
+
+    Args:
+        local_port: The local port number to expose (e.g., 8001).
+        log_file_path: Path to the file where Serveo SSH client output will be logged.
+        timeout_seconds: How long to wait for Serveo to provide a URL.
+
+    Returns:
+        A tuple (ssh_process, public_url). (None, None) on failure.
+    """
+    if not shutil.which("ssh"):
+        print("ERROR: 'ssh' command not found. Please ensure OpenSSH client is installed and in your PATH.")
+        return None, None
+
+    # Ensure log directory exists
+    os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+    
+    # Using a temporary file for UserKnownHostsFile might be more robust on some systems than /dev/null
+    # For simplicity, /dev/null is used here as specified in the plan.
+    # On Windows, /dev/null equivalent is NUL.
+    known_hosts_file = "/dev/null" if os.name != "nt" else "NUL"
+
+    serveo_command = [
+        "ssh",
+        "-o", "StrictHostKeyChecking=no",
+        "-o", f"UserKnownHostsFile={known_hosts_file}",
+        "-R", f"80:localhost:{local_port}",
+        "serveo.net"
+    ]
+
+    print(f"Attempting to start Serveo.net tunnel for localhost:{local_port}...")
+    print(f"Command: {' '.join(serveo_command)}")
+    print(f"Logging Serveo SSH client output to: {log_file_path}")
+
+    public_url = None
+    ssh_process = None
+    
+    try:
+        # We need to capture stdout to parse the URL.
+        # stderr will also be captured by the same pipe.
+        log_file = open(log_file_path, 'w')
+        ssh_process = subprocess.Popen(
+            serveo_command,
+            stdout=subprocess.PIPE, # Capture stdout for parsing
+            stderr=subprocess.STDOUT, # Redirect stderr to stdout pipe
+            text=True, # Decode output as text
+            bufsize=1,  # Line-buffered
+            universal_newlines=True, # Ensure consistent line endings
+            preexec_fn=os.setsid if os.name != "nt" else None # New process group for proper termination
+        )
+
+        # Add to managed_processes early so it can be cleaned up if something goes wrong
+        managed_processes[ssh_process.pid] = {
+            "process": ssh_process,
+            "command": serveo_command,
+            "log_file": log_file, # This log_file will store what we read from the pipe
+            "log_file_path": log_file_path,
+            "is_ngrok": False 
+        }
+        print(f"Serveo SSH process started with PID: {ssh_process.pid}. Waiting for URL...")
+
+        url_pattern = re.compile(r"Forwarding HTTP traffic from (https://\S+\.serveo\.net)")
+        
+        start_time = time.time()
+        if ssh_process.stdout:
+            for line in iter(ssh_process.stdout.readline, ''):
+                log_file.write(line) # Write to the main log file
+                log_file.flush()
+                print(f"[Serveo PID {ssh_process.pid}]: {line.strip()}") # Also print to console for live feedback
+                
+                match = url_pattern.search(line)
+                if match:
+                    public_url = match.group(1)
+                    print(f"Found Serveo public URL: {public_url}")
+                    break # URL found
+                
+                if time.time() - start_time > timeout_seconds:
+                    print(f"ERROR: Timeout ({timeout_seconds}s) waiting for Serveo URL.")
+                    break # Timeout
+                if ssh_process.poll() is not None: # Process terminated unexpectedly
+                    print(f"ERROR: Serveo SSH process terminated unexpectedly. Check log: {log_file_path}")
+                    break
+            
+            # If loop exited because readline returned '', process ended.
+            if ssh_process.poll() is not None and not public_url:
+                 print(f"ERROR: Serveo SSH process ended before URL was found. Check log: {log_file_path}")
+
+        else: # Should not happen if Popen was successful
+            print("ERROR: SSH process stdout stream not available.")
+
+
+    except FileNotFoundError:
+        print("ERROR: 'ssh' command not found. Please ensure OpenSSH client is installed and in your PATH.")
+        if ssh_process and ssh_process.pid in managed_processes:
+            stop_process(ssh_process.pid) # Clean up if partially started
+        return None, None
+    except Exception as e:
+        print(f"ERROR: An exception occurred while starting or monitoring Serveo: {e}")
+        if ssh_process and ssh_process.pid in managed_processes:
+            stop_process(ssh_process.pid) # Clean up
+        return None, None
+
+    if not public_url:
+        print("ERROR: Could not retrieve public URL from Serveo.net.")
+        if ssh_process: # If process was started, try to stop it
+            stop_process(ssh_process.pid)
+        return None, None
+    
+    # The ssh_process is kept running in the background by Popen.
+    # It's up to the caller to manage its lifecycle (e.g., via stop_process or stop_all_processes).
+    return ssh_process, public_url
+
+
+def stop_process(pid: int):
+    """
+    Stops a managed process and its process group.
+    Closes its log file.
+
+    Args:
+        pid: The PID of the process to stop.
+    """
+    if pid in managed_processes:
+        proc_info = managed_processes[pid]
+        process = proc_info["process"]
+        log_file = proc_info["log_file"]
+        command_str = ' '.join(proc_info["command"])
+
+        print(f"Stopping process PID {pid} ({command_str})...")
+        try:
+            if os.name == "nt":
+                # For Windows, taskkill is more reliable for process trees
+                subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)], check=True, capture_output=True)
+            else:
+                # Send SIGTERM to the entire process group
+                os.killpg(os.getpgid(pid), signal.SIGTERM)
+            
+            process.wait(timeout=5) # Wait for graceful termination
+            print(f"Process PID {pid} terminated gracefully.")
+        except subprocess.TimeoutExpired:
+            print(f"Process PID {pid} did not terminate gracefully, sending SIGKILL...")
+            if os.name == "nt":
+                 subprocess.run(["taskkill", "/F", "/T", "/PID", str(pid)], check=True, capture_output=True) # Force kill
+            else:
+                os.killpg(os.getpgid(pid), signal.SIGKILL)
+            print(f"Process PID {pid} killed.")
+        except Exception as e:
+            print(f"Error stopping process PID {pid}: {e}")
+        finally:
+            if log_file and not log_file.closed:
+                log_file.close()
+            del managed_processes[pid]
+    else:
+        print(f"Process with PID {pid} not found in managed list.")
+
+def stop_all_processes():
+    """
+    Stops all currently managed processes.
+    """
+    print("Stopping all managed processes...")
+    # Iterate over a copy of keys as `stop_process` modifies the dictionary
+    for pid in list(managed_processes.keys()):
+        stop_process(pid)
+    print("All managed processes have been requested to stop.")
+
+if __name__ == "__main__":
+    import sys # Import sys here for sys.executable
+    # Example Usage:
+    log_dir = os.path.join(os.getcwd(), "logs")
+    os.makedirs(log_dir, exist_ok=True)
+    
+    print("Starting a sample sleep process...")
+    sleep_log = os.path.join(log_dir, "sleep_test.log")
+    # Using sys.executable to ensure we use the same python interpreter
+    # For a real server, this would be [sys.executable, 'path/to/server_script.py']
+    # Note: sys.executable is not defined in this scope if this file is run directly without importing sys first.
+    # For the example, let's assume python is in path or use a simple command.
+    
+    # Test basic process start/stop
+    print("Starting a sample sleep process...")
+    sleep_log = os.path.join(log_dir, "sleep_test.log")
+    # Using a simple platform-independent sleep command for the example
+    sleep_command = ["timeout", "10"] if os.name == "nt" else ["sleep", "10"]
+    proc = start_process(sleep_command, sleep_log)
+    
+    if proc and proc.pid: # Check if proc is not None and has a pid
+        print(f"Sleep process PID: {proc.pid}")
+        print("Waiting for a few seconds before stopping...")
+        time.sleep(3)
+        stop_process(proc.pid)
+    else:
+        print("Failed to start sleep process.")
+
+    print("\nStarting another process to test stop_all...")
+    another_log = os.path.join(log_dir, "another_test.log")
+    # Using a simple platform-independent sleep command for the example
+    another_sleep_command = ["timeout", "10"] if os.name == "nt" else ["sleep", "10"]
+    proc2 = start_process(another_sleep_command, another_log)
+    if proc2 and proc2.pid:
+        print(f"Another process PID: {proc2.pid}")
+        time.sleep(1)
+        # stop_all_processes() # This would be called by atexit or explicitly
+    else:
+        print("Failed to start another process.")
+
+    # Test ngrok (manual execution needed if you want to see this run)
+    # print("\nTesting ngrok start (requires ngrok in PATH and a service on port 8888)...")
+    # ngrok_test_log = os.path.join(log_dir, "ngrok_test.log")
+    # ngrok_proc, ngrok_url = start_ngrok_and_get_url(8888, ngrok_test_log)
+    # if ngrok_proc and ngrok_url:
+    #     print(f"Ngrok started: PID {ngrok_proc.pid}, URL {ngrok_url}")
+    #     time.sleep(5) # Keep it running for 5s
+    #     # stop_process(ngrok_proc.pid) # stop_all_processes will handle it
+    # else:
+    #     print("Failed to start ngrok for testing.")
+    
+    # stop_all_processes() will be called by atexit if this script is run
+    # or can be called explicitly if needed.
+    # For this example, we'll let atexit handle it if processes were started.
+    # If running this __main__ block, ensure atexit is registered or call stop_all_processes()
+    import atexit
+    atexit.register(stop_all_processes)
+    print("Subprocess manager example finished. Check logs in 'logs' directory.")
+    print("Remaining managed processes (should be empty if all stopped):", managed_processes.keys())

--- a/examples/remote_eval_demo/README.md
+++ b/examples/remote_eval_demo/README.md
@@ -1,0 +1,68 @@
+# Remote Evaluation with Secrets and Serveo.net Demo
+
+This demo showcases how reward functions in `reward-kit` can securely call remote APIs. It uses **Serveo.net** (via SSH) to expose a local mock API service to the internet and manages secrets (API keys) through environment variables (simulating `fireworks secret` behavior). This setup prioritizes minimal external dependencies, relying on a standard SSH client.
+
+## Prerequisites
+
+1.  **Python Environment**: Ensure you have a Python environment with `reward-kit` and its development dependencies installed. This typically includes:
+    *   `fastapi`
+    *   `uvicorn`
+    *   `requests` (though not directly used by Serveo, it might be a general dev dependency)
+2.  **SSH Client**:
+    *   A working **SSH client must be installed and accessible in your system's PATH.** The demo script (`run_demo.py`) uses the `ssh` command to establish a tunnel with Serveo.net.
+    *   Most Linux and macOS systems have an SSH client pre-installed. Windows users might need to install one (e.g., OpenSSH included in modern Windows, or Git Bash).
+    *   Verify by typing `ssh -V` in your terminal.
+
+## Running the Demo
+
+The easiest way to run the full automated demo is using the Makefile target from the root of the `reward-kit` repository:
+
+```bash
+make demo-remote-eval
+```
+
+This command will:
+1.  Generate a temporary API key for the mock service for this session.
+2.  Start a local mock FastAPI server (defined in `mock_api_service.py`). This server will expect the generated API key.
+3.  Attempt to start an SSH tunnel using **Serveo.net** to expose the local mock server (running on port 8001 by default) to the internet.
+4.  Automatically fetch the public HTTPS URL provided by Serveo.net.
+5.  Run several test evaluations using this URL:
+    *   Using a reward function with a hardcoded API key (for demonstration of an insecure pattern, though it will use the session's generated key for the actual call).
+    *   Using a reward function that securely retrieves the API key from an environment variable.
+6.  Automatically stop the mock API server and the Serveo.net SSH tunnel when the script finishes or is interrupted.
+
+Log files for the mock API server and the Serveo SSH client output will be created in the `logs/remote_eval_demo/` directory at the root of the repository (e.g., `mock_api_service.log` and `serveo_ssh.log`).
+
+## How it Works
+
+*   **`run_demo.py`**: The main script that orchestrates the demo.
+    *   It generates a unique API key for the session using `generate_api_key.py`.
+    *   It starts `mock_api_service.py` as a background process, passing the generated API key and configured port via environment variables (`EXPECTED_API_KEY`, `PORT`).
+    *   It uses `development/utils/subprocess_manager.py` to manage these background processes and to start the Serveo.net tunnel.
+*   **`development/utils/subprocess_manager.py`**: A utility to start, stop, and manage background processes.
+    *   Includes `start_serveo_and_get_url()`: This function executes an `ssh` command to connect to Serveo.net, requests a tunnel, and parses the output to retrieve the public URL.
+    *   It handles automatic cleanup of all started processes.
+*   **`mock_api_service.py`**: A simple FastAPI application that simulates an external service.
+    *   It expects an `X-Secret-API-Key` header for its `/api/validate_data` endpoint.
+    *   It reads the `EXPECTED_API_KEY` and `PORT` from environment variables set by `run_demo.py`.
+*   **`rewards/remote_validator_reward_hardcoded.py`**: A reward function demonstrating an insecure way to handle an API key by having a placeholder for a hardcoded key. In the demo, `run_demo.py` overrides this by passing the `target_api_key`.
+*   **`rewards/remote_validator_reward_secure.py`**: A reward function demonstrating a secure way to handle an API key by fetching it from the `MOCK_SERVICE_API_KEY` environment variable (which `run_demo.py` sets for the test, using the dynamically generated API key).
+*   **`development/utils/generate_api_key.py`**: A utility to generate secure random API keys. `run_demo.py` calls this to create a unique key for each demo run.
+
+## Troubleshooting
+
+*   **"ERROR: 'ssh' command not found..."**:
+    *   Ensure an SSH client is installed and its location is added to your system's PATH.
+    *   Verify by typing `ssh -V` (or `ssh --version`) in your terminal.
+*   **"ERROR: Timeout (...) waiting for Serveo URL."** or **"ERROR: Could not retrieve public URL from Serveo.net."**:
+    *   Check the Serveo SSH client log file (e.g., `logs/remote_eval_demo/serveo_ssh.log`).
+    *   Serveo.net is a public service; its availability or performance can sometimes vary. Try running the demo again after a short wait.
+    *   Ensure your internet connection is stable and allows outbound SSH connections on port 22 (or the port Serveo.net uses if it differs).
+    *   Firewall or network policies might be blocking the SSH connection to `serveo.net`.
+*   **"ERROR: Serveo SSH process terminated unexpectedly"**:
+    *   Check the `serveo_ssh.log`. This could be due to network issues, Serveo.net service interruptions, or issues with the local SSH client setup.
+*   **API Key Mismatches / Authentication Failures in Reward Function Tests**:
+    *   The `run_demo.py` script generates a new API key for each session and configures the `mock_api_service.py` to expect this specific key.
+    *   The reward functions are then called with this generated key (either directly for the "hardcoded" example's override, or via an environment variable for the "secure" example).
+    *   If you see authentication failures, check the logs from `run_demo.py` to see the generated API key and ensure the mock service logs indicate it's expecting the same. The `X-Secret-API-Key` header sent by the reward functions must match what the mock service expects.
+*   **Port Conflicts**: The demo uses port `8001` by default for the local mock API service. If this port is already in use, `mock_api_service.py` might fail to start. The `run_demo.py` script sets this via the `MOCK_API_SERVICE_PORT` variable, which is then passed as a `PORT` environment variable to the mock service.

--- a/examples/remote_eval_demo/mock_api_service.py
+++ b/examples/remote_eval_demo/mock_api_service.py
@@ -1,0 +1,75 @@
+from fastapi import FastAPI, Header, HTTPException, Depends
+from pydantic import BaseModel
+import os
+import uvicorn
+
+# --- Configuration ---
+# The expected API key is set via the "EXPECTED_API_KEY" environment variable by the calling script (run_demo.py)
+EXPECTED_API_KEY = os.environ.get("EXPECTED_API_KEY")
+if not EXPECTED_API_KEY:
+    print("CRITICAL ERROR: EXPECTED_API_KEY environment variable not set for mock_api_service.")
+    print("This service will not function correctly without it. Using a default fallback.")
+    # Fallback to a default key if not set, though this indicates a setup issue with run_demo.py
+    EXPECTED_API_KEY = "d1bcc497c95659be6fbdcad869fa86390cefba53dc140b284d1508efdae81dd6_fallback"
+
+# The port is set via the "PORT" environment variable by the calling script (run_demo.py)
+SERVICE_PORT = int(os.environ.get("PORT", 8001))
+
+
+app = FastAPI(
+    title="Mock API Service for Reward Kit Demo",
+    description="A simple API service that requires an API key for a specific endpoint.",
+    version="0.1.0"
+)
+
+# --- Models ---
+class Item(BaseModel):
+    name: str
+    data: dict
+
+class SuccessResponse(BaseModel):
+    message: str
+    received_item: Item
+
+# --- Dependencies ---
+async def verify_api_key(x_secret_api_key: str = Header(None)):
+    """
+    Dependency to verify the provided API key in the X-Secret-API-Key header.
+    """
+    if not x_secret_api_key:
+        raise HTTPException(status_code=401, detail="X-Secret-API-Key header missing")
+    if x_secret_api_key != EXPECTED_API_KEY:
+        # Log the received key vs expected key for easier debugging if needed, but be careful with logging secrets.
+        # print(f"DEBUG: Received key: '{x_secret_api_key}', Expected key: '{EXPECTED_API_KEY}'")
+        raise HTTPException(status_code=403, detail="Invalid API Key")
+    return x_secret_api_key
+
+# --- Endpoints ---
+@app.get("/")
+async def read_root():
+    return {"message": "Mock API Service is running. Use /api/validate_data to test."}
+
+@app.post("/api/validate_data", response_model=SuccessResponse)
+async def validate_data(
+    item: Item,
+    api_key: str = Depends(verify_api_key) # Apply API key verification
+):
+    """
+    Validates data if the correct API key is provided.
+    Echoes back the received item upon successful validation.
+    """
+    # In a real scenario, you might perform some processing on 'item' here.
+    # For this demo, we just acknowledge receipt and echo it back.
+    return SuccessResponse(
+        message="Data validated successfully with API Key.",
+        received_item=item
+    )
+
+# --- Main execution for local testing ---
+if __name__ == "__main__":
+    print(f"Mock API Service starting...")
+    print(f"Expecting API Key (X-Secret-API-Key): '{EXPECTED_API_KEY}' (Set by 'EXPECTED_API_KEY' env var)")
+    print(f"Service will run on port: {SERVICE_PORT} (Set by 'PORT' env var)")
+    print("This script is typically run by run_demo.py, which sets these environment variables.")
+    
+    uvicorn.run(app, host="127.0.0.1", port=SERVICE_PORT)

--- a/examples/remote_eval_demo/rewards/remote_validator_reward_hardcoded.py
+++ b/examples/remote_eval_demo/rewards/remote_validator_reward_hardcoded.py
@@ -1,0 +1,178 @@
+from typing import Dict, List, Any, Union, Optional
+import requests # Using requests library for HTTP calls
+
+# Assuming reward_kit is installed and these are the correct import paths
+# Adjust if necessary based on the actual package structure
+from reward_kit.reward_function import reward_function
+from reward_kit.models import Message, EvaluateResult, MetricResult
+
+# --- Configuration (Hardcoded for Strategy A) ---
+# IMPORTANT: This is a placeholder for a default URL if the tunnel URL isn't provided.
+# The demo (run_demo.py) will override this with the actual tunnel URL via 'target_service_url' kwarg.
+DEFAULT_TARGET_SERVICE_URL = "YOUR_TUNNEL_URL_HERE" 
+# This key demonstrates hardcoding. The demo (run_demo.py) overrides this with `target_api_key` kwarg.
+HARDCODED_API_KEY = "d1bcc497c95659be6fbdcad869fa86390cefba53dc140b284d1508efdae81dd6" 
+
+@reward_function
+def remote_validator_reward_hardcoded(
+    messages: Union[List[Dict[str, Any]], List[Message]],
+    ground_truth: Optional[str] = None,
+    # kwargs is used to pass the actual target_service_url and target_api_key from run_demo.py
+    **kwargs: Any 
+) -> EvaluateResult:
+    """
+    Evaluates by calling a remote API using a hardcoded API key (by default) and a target URL.
+
+    This function demonstrates an insecure way of handling secrets (API key) and configurations (URL).
+    The `run_demo.py` script will typically override both `target_service_url` and `target_api_key` via kwargs.
+
+    Args:
+        messages: List of conversation messages. The last assistant message's content
+                  is used as part of the payload if available.
+        ground_truth: Optional expected correct answer (not used in this basic remote call).
+        **kwargs: Additional arguments.
+                  'target_service_url': Overrides DEFAULT_TARGET_SERVICE_URL. This is expected from run_demo.py.
+                  'target_api_key': Overrides HARDCODED_API_KEY. This is expected from run_demo.py.
+
+    Returns:
+        EvaluateResult with evaluation score and metrics based on API response.
+    """
+    # Use kwargs to get the actual URL and API key, falling back to defaults if not provided.
+    # run_demo.py is expected to provide these.
+    target_service_url = kwargs.get('target_service_url', DEFAULT_TARGET_SERVICE_URL)
+    api_key = kwargs.get('target_api_key', HARDCODED_API_KEY)
+
+    if target_service_url == "YOUR_TUNNEL_URL_HERE":
+        # This check is mostly for when testing this file directly without run_demo.py
+        return EvaluateResult(
+            score=0.0,
+            reason="Placeholder DEFAULT_TARGET_SERVICE_URL is not replaced and 'target_service_url' not provided via kwargs.",
+            is_score_valid=False,
+            metrics={}
+        )
+
+    api_endpoint = f"{target_service_url.rstrip('/')}/api/validate_data"
+
+    # Construct a payload from messages (e.g., use the last assistant message)
+    payload_data = {"info": "Default payload"}
+    if messages:
+        last_message = messages[-1]
+        if isinstance(last_message, Message): # If using Message Pydantic model
+            if last_message.role == "assistant" and last_message.content:
+                payload_data = {"info": "From assistant message", "content": last_message.content}
+        elif isinstance(last_message, dict): # If using raw dicts
+             if last_message.get("role") == "assistant" and last_message.get("content"):
+                payload_data = {"info": "From assistant message", "content": last_message.get("content")}
+    
+    item_payload = {"name": "TestItem", "data": payload_data}
+    headers = {"X-Secret-API-Key": api_key, "Content-Type": "application/json"}
+
+    try:
+        response = requests.post(api_endpoint, json=item_payload, headers=headers, timeout=10)
+        
+        if response.status_code == 200:
+            response_data = response.json()
+            return EvaluateResult(
+                score=1.0,
+                reason=f"API call successful: {response_data.get('message', 'OK')}",
+                is_score_valid=True,
+                metrics={ # Only add api_response_code metric for successful calls
+                    "api_response_code": MetricResult(score=1.0, is_score_valid=True, reason=f"HTTP Status Code {response.status_code}")
+                }
+            )
+        elif response.status_code == 401:
+             return EvaluateResult(
+                score=0.0,
+                reason=f"API Authentication Error (401): {response.json().get('detail', 'Unauthorized - Header missing?')}",
+                is_score_valid=True,
+                metrics={} # No specific metric score, error is in reason/main score
+            )
+        elif response.status_code == 403:
+            return EvaluateResult(
+                score=0.0,
+                reason=f"API Authorization Error (403): {response.json().get('detail', 'Invalid API Key')}",
+                is_score_valid=True,
+                metrics={} # No specific metric score, error is in reason/main score
+            )
+        else:
+            return EvaluateResult(
+                score=0.0,
+                reason=f"API call failed with status {response.status_code}: {response.text}",
+                is_score_valid=True,
+                metrics={} # No specific metric score, error is in reason/main score
+            )
+    except requests.exceptions.RequestException as e:
+        return EvaluateResult(
+            score=0.0,
+            reason=f"Network or request error: {str(e)}",
+            is_score_valid=False, 
+            metrics={}
+        )
+    except Exception as e:
+        return EvaluateResult(
+            score=0.0,
+            reason=f"An unexpected error occurred: {str(e)}",
+            is_score_valid=False,
+            metrics={}
+        )
+
+if __name__ == '__main__':
+    # Example of how to test this function locally (requires mock API and a tunnel like Serveo/Ngrok running)
+    # 1. Start mock_api_service.py (e.g., python examples/remote_eval_demo/mock_api_service.py)
+    # 2. Start your tunnel (e.g., ngrok http 8001 or ssh -R 80:localhost:8001 serveo.net) 
+    #    and update DEFAULT_TARGET_SERVICE_URL above or pass 'target_service_url' as a kwarg.
+    # 3. Run this script (e.g., python examples/remote_eval_demo/rewards/remote_validator_reward_hardcoded.py)
+
+    print("Testing remote_validator_reward_hardcoded function...")
+    
+    manual_test_url = "http://localhost:8001" 
+    effective_url_for_direct_test = DEFAULT_TARGET_SERVICE_URL
+    if DEFAULT_TARGET_SERVICE_URL == "YOUR_TUNNEL_URL_HERE":
+        print(f"\nNote: DEFAULT_TARGET_SERVICE_URL is a placeholder. For direct testing, either update it")
+        print(f"or ensure your mock service is reachable at '{manual_test_url}'. Using '{manual_test_url}'.")
+        effective_url_for_direct_test = manual_test_url
+    
+    print(f"Using Target Service URL for direct test: {effective_url_for_direct_test}")
+    print(f"Using API Key for direct test: {HARDCODED_API_KEY}")
+
+    sample_messages_valid = [
+        Message(role="user", content="Hello"),
+        Message(role="assistant", content="This is a test response for validation.")
+    ]
+    result_valid = remote_validator_reward_hardcoded(
+        messages=sample_messages_valid,
+        target_service_url=effective_url_for_direct_test, 
+        target_api_key=HARDCODED_API_KEY 
+    )
+    print(f"\nTest with (presumably) valid key:")
+    print(f"  Score: {result_valid.score}")
+    print(f"  Reason: {result_valid.reason}")
+    if result_valid.metrics:
+        for k, v_metric in result_valid.metrics.items(): # Renamed v to v_metric
+            print(f"  Metric '{k}': Score={v_metric.score}, Valid={v_metric.is_score_valid}, Reason={v_metric.reason}")
+
+    sample_messages_invalid_key = [Message(role="assistant", content="Test with wrong key")]
+    result_invalid_key = remote_validator_reward_hardcoded(
+        messages=sample_messages_invalid_key,
+        target_service_url=effective_url_for_direct_test, 
+        target_api_key="WRONG_KEY_SHOULD_FAIL"
+    )
+    print(f"\nTest with invalid key (WRONG_KEY_SHOULD_FAIL):")
+    print(f"  Score: {result_invalid_key.score}")
+    print(f"  Reason: {result_invalid_key.reason}")
+    if result_invalid_key.metrics: # Added metrics check
+        for k, v_metric in result_invalid_key.metrics.items():
+            print(f"  Metric '{k}': Score={v_metric.score}, Valid={v_metric.is_score_valid}, Reason={v_metric.reason}")
+
+    print(f"\nTest with a bad Tunnel URL (simulating network error):")
+    result_bad_url = remote_validator_reward_hardcoded(
+        messages=sample_messages_valid,
+        target_service_url="http://localhost:12345" 
+    )
+    print(f"  Score: {result_bad_url.score}")
+    print(f"  Reason: {result_bad_url.reason}")
+    if result_bad_url.metrics: # Added metrics check
+        for k, v_metric in result_bad_url.metrics.items():
+            print(f"  Metric '{k}': Score={v_metric.score}, Valid={v_metric.is_score_valid}, Reason={v_metric.reason}")
+
+    print("\nNote: For these tests to pass, the mock FastAPI service must be running and your tunnel (if used) must be correctly forwarding to it.")

--- a/examples/remote_eval_demo/rewards/remote_validator_reward_secure.py
+++ b/examples/remote_eval_demo/rewards/remote_validator_reward_secure.py
@@ -1,0 +1,174 @@
+from typing import Dict, List, Any, Union, Optional
+import requests
+import os # For accessing environment variables
+
+# Assuming reward_kit is installed and these are the correct import paths
+from reward_kit.reward_function import reward_function
+from reward_kit.models import Message, EvaluateResult, MetricResult
+
+# --- Configuration (Secure - via Environment Variable) ---
+# IMPORTANT: This is a placeholder for a default URL if the tunnel URL isn't provided.
+# The demo (run_demo.py) will override this with the actual tunnel URL via 'target_service_url' kwarg.
+DEFAULT_TARGET_SERVICE_URL = "YOUR_TUNNEL_URL_HERE" 
+# The API key will be fetched from this environment variable.
+# run_demo.py sets this environment variable before calling.
+API_KEY_ENV_VAR = "MOCK_SERVICE_API_KEY" # This is the var name the function looks for.
+
+@reward_function
+def remote_validator_reward_secure(
+    messages: Union[List[Dict[str, Any]], List[Message]],
+    ground_truth: Optional[str] = None,
+    **kwargs: Any
+) -> EvaluateResult:
+    """
+    Evaluates by calling a remote API using an API key
+    retrieved from an environment variable (simulating `fireworks secret`).
+
+    Args:
+        messages: List of conversation messages. The last assistant message's content
+                  is used as part of the payload if available.
+        ground_truth: Optional expected correct answer.
+        **kwargs: Additional arguments.
+                  'target_service_url': Overrides DEFAULT_TARGET_SERVICE_URL if provided. Expected from run_demo.py.
+                  'api_key_env_var': Overrides API_KEY_ENV_VAR if provided (less common for this secure version).
+
+    Returns:
+        EvaluateResult with evaluation score and metrics based on API response.
+    """
+    target_service_url = kwargs.get('target_service_url', DEFAULT_TARGET_SERVICE_URL)
+    # Allow overriding the env var name itself, though typically it's fixed for a given reward function.
+    api_key_env_to_use = kwargs.get('api_key_env_var', API_KEY_ENV_VAR) 
+    
+    if target_service_url == "YOUR_TUNNEL_URL_HERE":
+        return EvaluateResult(
+            score=0.0,
+            reason=f"Placeholder DEFAULT_TARGET_SERVICE_URL is not replaced. Please pass 'target_service_url' in kwargs.",
+            is_score_valid=False,
+            metrics={}
+        )
+
+    api_key = os.getenv(api_key_env_to_use)
+
+    if not api_key:
+        return EvaluateResult(
+            score=0.0,
+            reason=f"API Key not found in environment variable '{api_key_env_to_use}'. " \
+                   f"Ensure it's set (e.g., via 'fireworks secret set {api_key_env_to_use} your_key' or 'export {api_key_env_to_use}=your_key' for local tests).",
+            is_score_valid=False, # Cannot proceed without API key
+            metrics={}
+        )
+
+    api_endpoint = f"{target_service_url.rstrip('/')}/api/validate_data"
+
+    payload_data = {"info": "Default payload for secure call"}
+    if messages:
+        last_message = messages[-1]
+        if isinstance(last_message, Message):
+            if last_message.role == "assistant" and last_message.content:
+                payload_data = {"info": "From assistant message (secure)", "content": last_message.content}
+        elif isinstance(last_message, dict):
+             if last_message.get("role") == "assistant" and last_message.get("content"):
+                payload_data = {"info": "From assistant message (secure)", "content": last_message.get("content")}
+
+    item_payload = {"name": "SecureTestItem", "data": payload_data}
+    headers = {"X-Secret-API-Key": api_key, "Content-Type": "application/json"}
+
+    try:
+        response = requests.post(api_endpoint, json=item_payload, headers=headers, timeout=10)
+        
+        if response.status_code == 200:
+            response_data = response.json()
+            return EvaluateResult(
+                score=1.0,
+                reason=f"API call successful (secure): {response_data.get('message', 'OK')}",
+                is_score_valid=True,
+                metrics={ # Only add api_response_code metric for successful calls
+                    "api_response_code": MetricResult(score=1.0, is_score_valid=True, reason=f"HTTP Status Code {response.status_code}")
+                }
+            )
+        elif response.status_code == 401:
+             return EvaluateResult(
+                score=0.0,
+                reason=f"API Authentication Error (401) (secure): {response.json().get('detail', 'Unauthorized - Header missing?')}",
+                is_score_valid=True,
+                metrics={} # No specific metric score, error is in reason/main score
+            )
+        elif response.status_code == 403:
+            return EvaluateResult(
+                score=0.0,
+                reason=f"API Authorization Error (403) (secure): {response.json().get('detail', 'Invalid API Key')}",
+                is_score_valid=True,
+                metrics={} # No specific metric score, error is in reason/main score
+            )
+        else:
+            return EvaluateResult(
+                score=0.0,
+                reason=f"API call failed with status {response.status_code} (secure): {response.text}",
+                is_score_valid=True,
+                metrics={} # No specific metric score, error is in reason/main score
+            )
+    except requests.exceptions.RequestException as e:
+        return EvaluateResult(
+            score=0.0,
+            reason=f"Network or request error (secure): {str(e)}",
+            is_score_valid=False,
+            metrics={}
+        )
+    except Exception as e:
+        return EvaluateResult(
+            score=0.0,
+            reason=f"An unexpected error occurred (secure): {str(e)}",
+            is_score_valid=False,
+            metrics={}
+        )
+
+if __name__ == '__main__':
+    # Example of how to test this function locally
+    # 1. Start mock_api_service.py
+    # 2. Start your tunnel (e.g., ngrok http 8001 or ssh -R 80:localhost:8001 serveo.net) 
+    #    and update DEFAULT_TARGET_SERVICE_URL above or pass 'target_service_url' as a kwarg.
+    # 3. Set the MOCK_SERVICE_API_KEY environment variable:
+    #    export MOCK_SERVICE_API_KEY="your_actual_api_key_for_mock_service" 
+    #    (e.g., the one mock_api_service.py expects)
+    # 4. Run this script.
+
+    print("Testing remote_validator_reward_secure function...")
+    
+    manual_test_url = "http://localhost:8001" 
+
+    effective_url_for_direct_test = DEFAULT_TARGET_SERVICE_URL
+    if DEFAULT_TARGET_SERVICE_URL == "YOUR_TUNNEL_URL_HERE":
+        print(f"\nNote: DEFAULT_TARGET_SERVICE_URL is a placeholder. For direct testing, either update it")
+        print(f"or ensure your mock service is reachable at '{manual_test_url}'. Using '{manual_test_url}'.")
+        effective_url_for_direct_test = manual_test_url
+
+    actual_api_key_for_test = os.getenv(API_KEY_ENV_VAR)
+
+    if effective_url_for_direct_test == "YOUR_TUNNEL_URL_HERE" and DEFAULT_TARGET_SERVICE_URL == "YOUR_TUNNEL_URL_HERE": 
+        print(f"\nERROR: Please update 'DEFAULT_TARGET_SERVICE_URL' or 'manual_test_url' in this script with your actual tunnel URL for direct testing.")
+    elif not actual_api_key_for_test:
+        print(f"\nERROR: Environment variable '{API_KEY_ENV_VAR}' is not set. Please set it to your mock service API key for testing.")
+        print(f"  Example: export {API_KEY_ENV_VAR}=\"your_key_here\"")
+    else:
+        print(f"Using Target Service URL for direct test: {effective_url_for_direct_test}")
+        print(f"Using API Key from env var '{API_KEY_ENV_VAR}': {'*' * (len(actual_api_key_for_test) - 4) + actual_api_key_for_test[-4:] if actual_api_key_for_test else 'Not Set'}")
+
+        sample_messages = [
+            Message(role="user", content="Hello secure world"),
+            Message(role="assistant", content="This is a secure test response.")
+        ]
+        
+        result = remote_validator_reward_secure(
+            messages=sample_messages,
+            target_service_url=effective_url_for_direct_test 
+        )
+        
+        print(f"\nTest result:")
+        print(f"  Score: {result.score}")
+        print(f"  Reason: {result.reason}")
+        if result.metrics:
+            for k, v_metric in result.metrics.items(): # Renamed v to v_metric
+                print(f"  Metric '{k}': Score={v_metric.score}, Valid={v_metric.is_score_valid}, Reason={v_metric.reason}")
+
+    print(f"\nNote: For these tests to pass, the mock FastAPI service must be running,")
+    print(f"your tunnel must be correctly forwarding, and the '{API_KEY_ENV_VAR}' environment variable must be set correctly.")

--- a/examples/remote_eval_demo/run_demo.py
+++ b/examples/remote_eval_demo/run_demo.py
@@ -1,0 +1,198 @@
+import os
+import sys
+import subprocess
+import time
+import atexit # For cleanup
+
+# Adjust the Python path to include the root of the reward-kit project
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, project_root)
+
+try:
+    from reward_kit.models import Message
+    from examples.remote_eval_demo.rewards.remote_validator_reward_hardcoded import remote_validator_reward_hardcoded
+    from examples.remote_eval_demo.rewards.remote_validator_reward_secure import remote_validator_reward_secure
+    # Import from subprocess_manager
+    from development.utils.subprocess_manager import start_process, start_serveo_and_get_url, stop_all_processes, stop_process
+except ImportError as e:
+    print(f"Error importing modules: {e}")
+    print("Please ensure that reward-kit is installed or the PYTHONPATH is set correctly.")
+    print(f"Attempted to add project root: {project_root} to sys.path")
+    sys.exit(1)
+
+# --- Configuration for the Demo ---
+MOCK_API_SERVICE_PORT = 8001 # Port for the local mock API service
+LOG_DIR = os.path.join(project_root, "logs", "remote_eval_demo")
+MOCK_API_LOG_FILE = os.path.join(LOG_DIR, "mock_api_service.log")
+SERVEO_LOG_FILE = os.path.join(LOG_DIR, "serveo_ssh.log")
+MOCK_API_SCRIPT_PATH = os.path.join(project_root, "examples", "remote_eval_demo", "mock_api_service.py")
+API_KEY_GENERATOR_SCRIPT_PATH = os.path.join(project_root, "development", "utils", "generate_api_key.py")
+
+# This will be dynamically fetched from Serveo
+TUNNEL_PUBLIC_URL = None 
+
+# API key for the mock service. This will be generated.
+MOCK_API_KEY_VALUE = None
+
+# Environment variable name that the secure reward function will look for
+SECURE_REWARD_API_KEY_ENV_VAR = "MOCK_SERVICE_API_KEY"
+
+def generate_api_key() -> str | None:
+    """Generates an API key using the utility script."""
+    try:
+        print(f"Generating a new API key using {API_KEY_GENERATOR_SCRIPT_PATH}...")
+        result = subprocess.run(
+            [sys.executable, API_KEY_GENERATOR_SCRIPT_PATH],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        key = result.stdout.strip()
+        if not key:
+            print("ERROR: API key generation script produced an empty key.")
+            return None
+        print(f"Generated API Key: {key}")
+        return key
+    except FileNotFoundError:
+        print(f"ERROR: API key generator script not found at {API_KEY_GENERATOR_SCRIPT_PATH}")
+        return None
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: API key generation script failed: {e}")
+        print(f"Stdout: {e.stdout}")
+        print(f"Stderr: {e.stderr}")
+        return None
+
+def print_header(title):
+    print("\n" + "="*60)
+    print(f"DEMO: {title}")
+    print("="*60)
+
+def run_evaluation(reward_fn_name, reward_fn, messages, **kwargs):
+    print(f"\n--- Running: {reward_fn_name} ---")
+    try:
+        result = reward_fn(messages=messages, **kwargs)
+        print(f"  Score: {result.score}")
+        print(f"  Reason: {result.reason}")
+        print(f"  Is Valid: {result.is_score_valid}")
+        if result.metrics:
+            for k, v in result.metrics.items():
+                print(f"  Metric '{k}': Score={v.score}, Valid={v.is_score_valid}, Reason={v.reason}")
+    except Exception as e:
+        print(f"  ERROR during evaluation: {e}")
+    print("--- End ---")
+
+
+if __name__ == "__main__":
+    atexit.register(stop_all_processes) # Ensure cleanup on exit
+
+    print_header("Automated Remote Evaluation Demo with Serveo.net")
+
+    # Create log directory
+    os.makedirs(LOG_DIR, exist_ok=True)
+    print(f"Logs will be stored in: {LOG_DIR}")
+
+    # 1. Generate API Key
+    MOCK_API_KEY_VALUE = generate_api_key()
+    if not MOCK_API_KEY_VALUE:
+        print("Exiting demo due to API key generation failure.")
+        sys.exit(1)
+
+    # 2. Start Mock API Service
+    print_header("Starting Mock API Service")
+    mock_api_command = [sys.executable, MOCK_API_SCRIPT_PATH]
+    # Pass the generated API key to the mock service via an environment variable
+    mock_api_env = os.environ.copy()
+    mock_api_env["EXPECTED_API_KEY"] = MOCK_API_KEY_VALUE
+    mock_api_env["PORT"] = str(MOCK_API_SERVICE_PORT) # Ensure mock service uses the configured port
+
+    # Need to modify mock_api_service.py to accept EXPECTED_API_KEY and PORT from env
+    # For now, assuming mock_api_service.py is adapted or uses a default key if env var not found.
+    # The plan implies mock_api_service.py stores the "expected" API key.
+    # For a fully automated demo, it's better if mock_api_service.py reads this from an env var
+    # that this script sets.
+
+    # For now, let's assume mock_api_service.py has been updated to use EXPECTED_API_KEY from env.
+    # If not, the hardcoded key in mock_api_service.py must match the generated one, which is not feasible.
+    # The plan says: "Store the "expected" API key (e.g., from Step 1, or a consistent demo key)."
+    # This implies the mock service needs to know the key.
+    
+    # We will proceed by setting the EXPECTED_API_KEY env var for the mock service.
+    # The mock_api_service.py will need to be checked/updated to use this.
+    
+    mock_api_process = start_process(mock_api_command, MOCK_API_LOG_FILE, cwd=project_root, env=mock_api_env)
+    if not mock_api_process or mock_api_process.poll() is not None:
+        print(f"ERROR: Failed to start Mock API Service. Check log: {MOCK_API_LOG_FILE}")
+        sys.exit(1)
+    print(f"Mock API Service started with PID {mock_api_process.pid}. Waiting for it to initialize...")
+    time.sleep(5) # Give the server a moment to start
+
+    # 3. Start Serveo Tunnel
+    print_header("Starting Serveo.net Tunnel")
+    serveo_process, TUNNEL_PUBLIC_URL = start_serveo_and_get_url(MOCK_API_SERVICE_PORT, SERVEO_LOG_FILE)
+    if not TUNNEL_PUBLIC_URL or not serveo_process:
+        print("ERROR: Failed to start Serveo tunnel or get public URL.")
+        # stop_all_processes() will be called by atexit, which will stop the mock_api_process if it started.
+        sys.exit(1)
+    
+    print(f"Serveo Tunnel established: {TUNNEL_PUBLIC_URL}")
+    print(f"Serveo SSH client PID: {serveo_process.pid}")
+    print(f"Using Mock API Key for tests: {MOCK_API_KEY_VALUE}")
+    print(f"Secure reward function will look for env var: {SECURE_REWARD_API_KEY_ENV_VAR}")
+
+    sample_messages = [
+        Message(role="user", content="Test query for remote validation."),
+        Message(role="assistant", content="Assistant response to be validated remotely.")
+    ]
+
+    # --- Test 1: Hardcoded Reward Function (Correct Key) ---
+    print_header("Test 1: Hardcoded Reward Function (Correct Key)")
+    run_evaluation(
+        "remote_validator_reward_hardcoded (correct key)",
+        remote_validator_reward_hardcoded,
+        sample_messages,
+        target_service_url=TUNNEL_PUBLIC_URL,
+        target_api_key=MOCK_API_KEY_VALUE 
+    )
+
+    # --- Test 2: Hardcoded Reward Function (Incorrect Key) ---
+    print_header("Test 2: Hardcoded Reward Function (Incorrect Key)")
+    run_evaluation(
+        "remote_validator_reward_hardcoded (incorrect key)",
+        remote_validator_reward_hardcoded,
+        sample_messages,
+        target_service_url=TUNNEL_PUBLIC_URL,
+        target_api_key="THIS_IS_A_WRONG_KEY"
+    )
+
+    # --- Test 3: Secure Reward Function (Correct Key via Env Var) ---
+    print_header("Test 3: Secure Reward Function (Correct Key via Env Var)")
+    print(f"Setting environment variable for secure test: {SECURE_REWARD_API_KEY_ENV_VAR}={MOCK_API_KEY_VALUE}")
+    os.environ[SECURE_REWARD_API_KEY_ENV_VAR] = MOCK_API_KEY_VALUE
+    
+    run_evaluation(
+        "remote_validator_reward_secure (correct key from env)",
+        remote_validator_reward_secure,
+        sample_messages,
+        target_service_url=TUNNEL_PUBLIC_URL
+    )
+    del os.environ[SECURE_REWARD_API_KEY_ENV_VAR]
+    print(f"Cleared environment variable: {SECURE_REWARD_API_KEY_ENV_VAR}")
+
+
+    # --- Test 4: Secure Reward Function (API Key Env Var Not Set) ---
+    print_header("Test 4: Secure Reward Function (API Key Env Var Not Set)")
+    if os.getenv(SECURE_REWARD_API_KEY_ENV_VAR):
+         print(f"Warning: {SECURE_REWARD_API_KEY_ENV_VAR} was unexpectedly set. Deleting for test.")
+         del os.environ[SECURE_REWARD_API_KEY_ENV_VAR]
+
+    run_evaluation(
+        "remote_validator_reward_secure (API key env var not set)",
+        remote_validator_reward_secure,
+        sample_messages,
+        target_service_url=TUNNEL_PUBLIC_URL
+    )
+
+    print("\n" + "="*60)
+    print("DEMO SCRIPT FINISHED")
+    print("Review the outputs above. Mock API and Serveo tunnel were managed automatically.")
+    print("="*60)


### PR DESCRIPTION
# Implement automated remote evaluation demo with Serveo

This commit completes the setup for the remote evaluation demo using Serveo.net for automated tunneling, as outlined in development/readiness/remote_evaluation_setup_plan.md.

The demo now fully automates:
- Dynamic API key generation.
- Startup of a local mock API service configured with the dynamic key.
- Establishment of a public tunnel to the mock service using Serveo.net via SSH.
- Execution of reward functions against the tunneled service.
- Cleanup of all background processes.

Key changes include:
- Integrated Serveo.net tunneling in subprocess_manager.py and run_demo.py.
- Ensured correct propagation of environment variables (API key, port) to the mock API subprocess.
- Updated mock_api_service.py to use these environment variables.
- Modified generate_api_key.py to output only the raw key.
- Refactored reward functions for generic URL parameter handling and to resolve Pydantic validation errors related to 'metrics' field and 'MetricResult.score' constraints.
- Added a 'make demo-remote-eval' target to the Makefile.
- Overhauled the demo's README.md to reflect these changes.