### PR TITLE
Fix: Enable var-annotated mypy check and fix errors

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,7 @@ disallow_untyped_decorators = False
 no_implicit_optional = True
 strict_optional = True
 ignore_missing_imports = True
-disable_error_code = import-not-found, truthy-function, no-redef, assignment, union-attr, misc, name-defined, index, arg-type, operator, var-annotated, return-value, call-arg, attr-defined
+disable_error_code = import-not-found, truthy-function, no-redef, assignment, union-attr, misc, name-defined, index, arg-type, operator
 
 [mypy.plugins.pydantic.*]
 follow_imports = skip

--- a/reward_kit/agent/task_manager.py
+++ b/reward_kit/agent/task_manager.py
@@ -58,7 +58,7 @@ class TaskManager:
         Returns:
             task_ids: List of task IDs that were successfully registered
         """
-        task_ids = []
+        task_ids: List[str] = []
         dir_path = Path(directory_path)
 
         if not dir_path.exists() or not dir_path.is_dir():
@@ -221,7 +221,7 @@ class TaskManager:
             self.logger.error("No valid tasks to execute.")
             return {}
 
-        results = {}
+        results: Dict[str, Any] = {}
 
         if parallel and len(valid_task_ids) > 1:
             # Execute tasks in parallel with concurrency limit

--- a/reward_kit/cli_commands/preview.py
+++ b/reward_kit/cli_commands/preview.py
@@ -4,6 +4,7 @@ CLI command for previewing an evaluator.
 
 import json
 import sys  # For sys.exit
+from typing import Any, Dict, Iterator, List, Optional, Union
 from pathlib import Path
 
 import requests  # For making HTTP requests
@@ -76,7 +77,7 @@ def preview_command(args):
 
         evaluate_endpoint = f"{args.remote_url.rstrip('/')}/evaluate"
 
-        samples_iterator = []
+        samples_iterator: Union[List[Any], Iterator[Dict[str, Any]]] = []
         try:
             if args.samples:
                 # Assuming load_samples_from_file yields dicts with "messages" and optional "ground_truth"


### PR DESCRIPTION
This PR enables the 'var-annotated' mypy check and fixes the resulting type errors. Pytest started hanging after installing full [dev] dependencies, this will need further investigation.