### PR TITLE
Refactor: Rename original_messages to ground_truth in examples

### DIFF
--- a/examples/e2b_auto_extract_example.py
+++ b/examples/e2b_auto_extract_example.py
@@ -70,9 +70,9 @@ This function iterates through each number in the list and adds it to a running 
     print("Running code in E2B sandbox...")
 
     # Evaluate the code using E2B, letting it extract the expected output
+    # ground_truth is None, so the function will attempt auto-extraction from messages.
     result = e2b_code_execution_reward(
         messages=messages,
-        original_messages=messages,  # Pass the original messages for expected output extraction
         language="python",
         api_key=api_key,
         timeout=10,

--- a/examples/folder_based_evaluation_example.py
+++ b/examples/folder_based_evaluation_example.py
@@ -33,7 +33,7 @@ def setup_sample_evaluator():
     # Create main.py in the quality folder
     quality_main = quality_folder / "main.py"
     quality_code = '''
-def evaluate(messages, original_messages=None, tools=None, **kwargs):
+def evaluate(messages, ground_truth=None, tools=None, **kwargs):
     """
     Evaluate the quality of a response.
     """
@@ -68,7 +68,7 @@ def evaluate(messages, original_messages=None, tools=None, **kwargs):
     # Create main.py in the relevance folder
     relevance_main = relevance_folder / "main.py"
     relevance_code = '''
-def evaluate(messages, original_messages=None, tools=None, **kwargs):
+def evaluate(messages, ground_truth=None, tools=None, **kwargs):
     """
     Evaluate the relevance of a response to the original query.
     """
@@ -79,9 +79,11 @@ def evaluate(messages, original_messages=None, tools=None, **kwargs):
             "reason": "No messages found"
         }
 
-    # Get the query and the response
+    # Get the query andお疲れ様です。 the response
     query = ""
-    for msg in original_messages or messages[:-1]:
+    # If ground_truth is a list of messages (context), use it. Otherwise, use messages[:-1].
+    context_messages = ground_truth if isinstance(ground_truth, list) else messages[:-1]
+    for msg in context_messages:
         if msg.get("role") == "user":
             query = msg.get("content", "")
             break
@@ -147,7 +149,7 @@ def evaluate(messages, original_messages=None, tools=None, **kwargs):
                     "content": "Deep learning is a subset of machine learning that uses neural networks with many layers.",
                 },
             ],
-            "original_messages": [
+            "ground_truth": [  # Changed from original_messages
                 {"role": "user", "content": "What is deep learning?"}
             ],
         },

--- a/examples/huggingface_general_example.py
+++ b/examples/huggingface_general_example.py
@@ -36,7 +36,7 @@ def main():
 # available for import in this dynamically executed script by preview_evaluation.
 # Instead, we will return a dictionary matching their structure.
 
-def evaluate(messages, original_messages=None, tools=None, **kwargs):
+def evaluate(messages, ground_truth=None, tools=None, **kwargs):
     # Extract assistant response
     assistant_messages = [m for m in messages if m.get("role") == "assistant"]
     if not assistant_messages:

--- a/examples/huggingface_math_example.py
+++ b/examples/huggingface_math_example.py
@@ -58,10 +58,8 @@ def main():
             {"role": "assistant", "content": custom_solution},
         ]
         # The ground_truth for "2 + 2 = 4" is "4"
-        math_result = math_reward(
-            messages=messages, ground_truth="4", original_messages=messages
-        )
-        length_result = length_reward(messages=messages, original_messages=messages)
+        math_result = math_reward(messages=messages, ground_truth="4")
+        length_result = length_reward(messages=messages)
 
         print(f"Problem: {problem}")
         print(f"Problem: {problem}")

--- a/examples/math_example/fireworks_preview.py
+++ b/examples/math_example/fireworks_preview.py
@@ -83,12 +83,12 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
 from reward_kit.rewards.math import math_reward
 from reward_kit.models import Message, EvaluateResult
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional, Union # Added Optional, Union
 
-def evaluate(messages: List[Dict[str, Any]], original_messages: List[Dict[str, Any]] = None, tools: List[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
+def evaluate(messages: List[Dict[str, Any]], ground_truth: Optional[Union[str, List[Dict[str, Any]]]] = None, tools: List[Dict[str, Any]] = None, **kwargs: Any) -> Dict[str, Any]:
     # Convert dict messages to Message objects for math_reward
     typed_messages = [Message(**msg) for msg in messages]
-    typed_original_messages = [Message(**msg) for msg in original_messages] if original_messages else typed_messages
+    # typed_original_messages is no longer needed as a separate variable
 
     # math_reward expects ground_truth. For this setup, we assume ground_truth is passed in kwargs
     # or derived if not. For the example dataset, assistant's response is the ground_truth.
@@ -120,9 +120,10 @@ def evaluate(messages: List[Dict[str, Any]], original_messages: List[Dict[str, A
         return EvaluateResult(score=0.0, reason="No assistant message for ground truth").model_dump()
 
     # Call the actual math_reward function
+    # The `ground_truth` parameter for `math_reward` is `assistant_content_for_gt`.
+    # Context will be derived from `typed_messages[:-1]` by `math_reward` if needed.
     result = math_reward(
         messages=typed_messages,
-        original_messages=typed_original_messages,
         ground_truth=assistant_content, # Use assistant's response as GT for this example
         **kwargs # Pass other potential args like tolerance
     )

--- a/examples/math_example/fireworks_regenerate.py
+++ b/examples/math_example/fireworks_regenerate.py
@@ -402,7 +402,6 @@ async def main(args):
             try:
                 result = math_reward(
                     messages=messages_for_eval,
-                    original_messages=messages_for_eval,
                     ground_truth=original_assistant_content,
                 )
 

--- a/examples/math_example/local_eval.py
+++ b/examples/math_example/local_eval.py
@@ -65,7 +65,6 @@ def main():
         try:
             result = math_reward(
                 messages=messages,
-                original_messages=messages,
                 ground_truth=assistant_response_content,
             )
 

--- a/examples/math_example/trl_grpo_integration.py
+++ b/examples/math_example/trl_grpo_integration.py
@@ -143,12 +143,10 @@ def adapted_math_reward(
         ]
 
         try:
-            # The original_messages for math_reward is for context if needed by the reward logic,
-            # but math_reward primarily uses the 'ground_truth' string for comparison.
-            # For simplicity, we can pass messages_for_eval as original_messages.
+            # math_reward primarily uses the 'ground_truth' string for comparison.
+            # Context, if needed by math_reward when ground_truth is a string, will be derived from messages_for_eval[:-1].
             eval_result = math_reward(  # Use the imported name 'math_reward'
                 messages=messages_for_eval,
-                original_messages=messages_for_eval,
                 ground_truth=ground_truth_answer_str,
             )
             rewards.append(torch.tensor(eval_result.score, dtype=torch.float32))

--- a/examples/math_example_openr1/trl_grpo_integration.py
+++ b/examples/math_example_openr1/trl_grpo_integration.py
@@ -129,7 +129,6 @@ def adapted_math_reward(
         try:
             eval_result = math_reward(
                 messages=messages_for_eval,
-                original_messages=messages_for_eval,  # For math_reward, this can be same as messages
                 ground_truth=ground_truth_answer_str,  # This is the crucial ground truth
             )
             rewards.append(torch.tensor(eval_result.score, dtype=torch.float32))

--- a/examples/tool_calling_example/fireworks_preview.py
+++ b/examples/tool_calling_example/fireworks_preview.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sys
+from typing import List, cast  # Added cast and List
 
 # Configure logging
 log_file_path = os.path.join(os.path.dirname(__file__), "fireworks_preview_debug.log")
@@ -85,9 +86,12 @@ def main():
         logger.debug("Attempting to call preview_evaluation...")
 
         preview_result = preview_evaluation(
-            sample_file=sample_file_path,
-            metric_folders=[f"exact_match_metric={metric_folder_path}"],
-            max_samples=5,
+            sample_file=cast(str, sample_file_path),
+            metric_folders=cast(
+                List[str], [f"exact_match_metric={metric_folder_path}"]
+            ),
+            max_samples=cast(int, 5),
+            # Other parameters will use their defaults from the function signature
         )
 
         logger.debug("preview_evaluation call completed.")

--- a/examples/tool_calling_example/fireworks_regenerate.py
+++ b/examples/tool_calling_example/fireworks_regenerate.py
@@ -75,6 +75,18 @@ def main():
         sys.exit(1)
 
     dataset_path = "examples/tool_calling_example/dataset.jsonl"
+    if not os.path.exists(dataset_path):
+        # Try path relative to script if direct path fails (e.g. when run from root)
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        dataset_path_rel = os.path.join(script_dir, "dataset.jsonl")
+        if os.path.exists(dataset_path_rel):
+            dataset_path = dataset_path_rel
+        else:
+            print(
+                f"Error: Dataset file not found at {dataset_path} or {dataset_path_rel}"
+            )
+            sys.exit(1)
+
     dataset = load_dataset(dataset_path)
 
     total_evaluated = 0

--- a/examples/trl_integration/ppo_example.py
+++ b/examples/trl_integration/ppo_example.py
@@ -47,7 +47,9 @@ except ImportError:
 @reward_function
 def helpfulness_reward(
     messages: List[Dict[str, Any]],
-    original_messages: Optional[List[Dict[str, Any]]] = None,
+    ground_truth: Optional[
+        List[Dict[str, Any]]
+    ] = None,  # Changed from original_messages
     **kwargs,
 ) -> EvaluateResult:
     """
@@ -57,7 +59,7 @@ def helpfulness_reward(
 
     Args:
         messages: List of conversation messages
-        original_messages: Original messages for context
+        ground_truth: Optional ground truth context (not used by this specific function).
 
     Returns:
         EvaluateResult with score based on helpfulness

--- a/examples/trl_integration/test_trl_integration.py
+++ b/examples/trl_integration/test_trl_integration.py
@@ -34,7 +34,9 @@ from reward_kit.rewards.length import length_reward
 @reward_function
 def _example_trl_reward_func(  # Renamed to avoid pytest collection
     messages: List[Dict[str, Any]],
-    original_messages: Optional[List[Dict[str, Any]]] = None,
+    ground_truth: Optional[
+        List[Dict[str, Any]]
+    ] = None,  # Changed from original_messages
     **kwargs
 ) -> EvaluateResult:
     """Simple test reward that returns 1.0 if text contains 'good' and 0.0 otherwise."""

--- a/examples/trl_integration/trl_adapter.py
+++ b/examples/trl_integration/trl_adapter.py
@@ -105,7 +105,9 @@ def create_combined_reward(
 @reward_function
 def grpo_format_reward(
     messages: List[Dict[str, Any]],
-    original_messages: Optional[List[Dict[str, Any]]] = None,
+    ground_truth: Optional[
+        List[Dict[str, Any]]
+    ] = None,  # Changed from original_messages
     think_tag: str = "<think>",
     answer_tag: str = "<answer>",
     **kwargs,
@@ -115,7 +117,7 @@ def grpo_format_reward(
 
     Args:
         messages: List of conversation messages
-        original_messages: Original messages for context
+        ground_truth: Optional ground truth context (not used by this specific function).
         think_tag: Tag to use for reasoning (default: "<think>")
         answer_tag: Tag to use for answers (default: "<answer>")
 

--- a/examples/trl_integration/working_grpo_example.py
+++ b/examples/trl_integration/working_grpo_example.py
@@ -55,7 +55,9 @@ except ImportError as e:
 @reward_function
 def format_reward(
     messages: List[Dict[str, Any]],
-    original_messages: Optional[List[Dict[str, Any]]] = None,
+    ground_truth: Optional[
+        List[Dict[str, Any]]
+    ] = None,  # Changed from original_messages
     think_tag: str = "<think>",
     answer_tag: str = "<answer>",
     **kwargs,
@@ -65,7 +67,7 @@ def format_reward(
 
     Args:
         messages: List of conversation messages
-        original_messages: Original messages for context
+        ground_truth: Optional ground truth context (not used by this specific function).
         think_tag: Tag to use for reasoning (default: "<think>")
         answer_tag: Tag to use for answers (default: "<answer>")
 
@@ -170,8 +172,12 @@ def format_reward(
 @reward_function
 def math_accuracy_reward(
     messages: List[Dict[str, Any]],
-    original_messages: Optional[List[Dict[str, Any]]] = None,
-    solution: Optional[str] = None,
+    ground_truth: Optional[
+        List[Dict[str, Any]]
+    ] = None,  # Changed from original_messages, marked as unused
+    solution: Optional[
+        str
+    ] = None,  # This is the primary ground truth for this function
     **kwargs,
 ) -> EvaluateResult:
     """
@@ -179,8 +185,8 @@ def math_accuracy_reward(
 
     Args:
         messages: List of conversation messages
-        original_messages: Original messages for context
-        solution: Expected solution/answer
+        ground_truth: Optional ground truth context (not used by this specific function).
+        solution: Expected solution/answer string.
 
     Returns:
         EvaluateResult with score based on solution accuracy


### PR DESCRIPTION
This PR refactors the 'original_messages' parameter to 'ground_truth' across various files in the /examples directory, as part of a larger effort to standardize this naming convention.