### PR TITLE
Refactor: Rename original_messages to ground_truth in reward_kit

### DIFF
--- a/reward_kit/rewards/cpp_code.py
+++ b/reward_kit/rewards/cpp_code.py
@@ -642,9 +642,7 @@ def _ioi_cpp_code_reward_impl(
 
     Args:
         messages: Generated conversation messages
-        original_messages: Original conversation context (optional)
-        expected_output: Expected output from code execution (for single-case testing)
-        test_cases: List of test cases for batch testing
+        ground_truth: Expected output string or list of test case dictionaries.
         language: Programming language ("c" or "cpp")
         version: Version of the compiler to use
         timeout: Maximum execution time in milliseconds
@@ -910,9 +908,7 @@ def binary_cpp_code_reward(
 
     Args:
         messages: Generated conversation messages
-        original_messages: Original conversation context (optional)
-        expected_output: Expected output from code execution (for single-case testing)
-        test_cases: List of test cases for batch testing
+        ground_truth: Expected output string or list of test case dictionaries.
         language: Programming language ("c" or "cpp")
         version: Version of the compiler to use
         timeout: Maximum execution time in milliseconds

--- a/reward_kit/rewards/function_calling.py
+++ b/reward_kit/rewards/function_calling.py
@@ -24,7 +24,6 @@ def match_function_call(
     messages: List[
         Dict[str, str]
     ],  # messages is for context if needed, not directly used here for func call parts
-    # original_messages: List[Dict[str, str]], # Removed
     function_name: str,
     parsed_arguments: Dict[str, Any],
     expected_call_schema: Dict[str, Any],


### PR DESCRIPTION
This PR refactors the 'original_messages' parameter to 'ground_truth' within the reward_kit core files (reward_function.py, evaluation.py, server.py, and relevant rewards like cpp_code.py and function_calling.py).