### PR TITLE
decorate convert result to dict in the end

### DIFF
--- a/reward_kit/models.py
+++ b/reward_kit/models.py
@@ -36,7 +36,7 @@ class MetricResult(BaseModel):
 
     is_score_valid: bool = True
     score: float = Field(..., ge=0.0, le=1.0)
-    reason: str
+    reason: str = None
 
     def __getitem__(self, key: str) -> Any:
         if (

--- a/reward_kit/typed_interface.py
+++ b/reward_kit/typed_interface.py
@@ -141,8 +141,8 @@ def reward_function(func: EvaluateFunction) -> HybridEvaluateFunction:
         except ValidationError as err:
             raise ValueError(f"Return value failed validation:\n{err}") from None
 
-        # 3. Return the EvaluateResult object directly
-        # The result_model is an instance of our hybrid EvaluateResult
-        return result_model
+        # 3. Return a dict converted from a hybrid EvaluateResult
+        # The result_model is a dict converted from a hybrid EvaluateResult
+        return result_model.model_dump()
 
     return cast(HybridEvaluateFunction, wrapper)


### PR DESCRIPTION
1. in the @reward_function decorator, we only **check&enforce** the return type to be a EvaluateResult, but when we return the value back, we convert it to dict so the result type can be the same when people are not using the decorator and EvaluateResult pydantic type. 


2. make the reason field optional