### PR TITLE
Refactor: Update dataset params & add Hydra for convert_dataset

### DIFF
--- a/development/notes/hydra_dataset_refactor_plan.md
+++ b/development/notes/hydra_dataset_refactor_plan.md
@@ -1,0 +1,153 @@
+# Plan: Hydra for First-Class Dataset Management in Examples
+
+This plan outlines the steps to refactor example scripts to use Hydra for dataset configuration, making datasets a "first-class citizen" in the codebase. This will improve consistency, reusability, and clarity for users.
+
+**Phase 1: Core Dataset Handling Module & Hydra Schemas**
+
+1.  **Define a Centralized Dataset Loading/Processing Logic:**
+    *   Create a new Python module within the `reward_kit` core, perhaps `reward_kit/datasets/loader.py` or `reward_kit/data_handling.py`.
+    *   This module will contain functions responsible for:
+        *   Loading datasets from various sources (Hugging Face, local files like JSONL).
+        *   Applying common preprocessing steps (e.g., formatting messages, extracting specific columns based on configuration).
+        *   Potentially caching datasets.
+    *   The functions in this module will be driven by Hydra configurations.
+
+2.  **Design Hydra Configuration Schemas for Datasets:**
+    *   Define structured configs (e.g., using dataclasses with `hydra_zen` or just well-defined YAML structures) for datasets. This promotes type safety and discoverability.
+    *   A base dataset schema might include:
+        *   `source_type`: (e.g., `huggingface`, `jsonl_file`)
+        *   `path_or_name`: (HF dataset name or local file path)
+        *   `split`: (e.g., `train`, `test`, `validation`)
+        *   `config_name`: (for HF datasets with multiple configs)
+        *   `preprocessing_steps`: (list of preprocessing functions/configs to apply)
+        *   `column_mapping`: (flexible mapping for `query`, `solution`, `ground_truth`, etc., if needed beyond defaults)
+    *   Example schema structure in YAML (to be potentially backed by Python dataclasses):
+        ```yaml
+        # conf/dataset/base_dataset.yaml (abstract base)
+        _target_: reward_kit.datasets.loader.load_and_process_dataset # Points to the new central loader
+        source_type: ???
+        path_or_name: ???
+        split: "train"
+        config_name: null
+        column_mapping:
+          query: "problem"
+          solution: "solution" # Or assistant_response
+          ground_truth: "answer" # Or expected_output
+        # Add other common fields like max_samples, shuffle, etc.
+        ```
+        ```yaml
+        # conf/dataset/gsm8k.yaml
+        defaults:
+          - base_dataset
+        source_type: huggingface
+        path_or_name: "gsm8k"
+        config_name: "main"
+        # Override column_mapping if gsm8k uses different names
+        ```
+        ```yaml
+        # conf/dataset/custom_jsonl.yaml
+        defaults:
+          - base_dataset
+        source_type: jsonl_file
+        path_or_name: "path/to/my/data.jsonl" # Can be relative to a data root or absolute
+        ```
+
+3.  **Refactor `examples/math_example/convert_dataset.py` (Already Partially Done):**
+    *   This script now uses Hydra. We can further refine its configuration to use the new structured dataset schema from a central `conf/dataset/` location.
+    *   Instead of many top-level dataset parameters in its local `config.yaml`, it would have a nested `dataset` group that refers to a global dataset config:
+        ```yaml
+        # examples/math_example/conf/config.yaml (updated)
+        defaults:
+          - dataset: gsm8k # Points to project_root/conf/dataset/gsm8k.yaml
+          - _self_
+
+        # ... (processing and output sections remain)
+
+        # The 'dataset' group will be populated from the global dataset config
+        dataset:
+          # Parameters here can override those from the chosen dataset default
+          split: "test" # Example override
+        ```
+    *   The `convert_dataset.py` script would then access dataset parameters via `cfg.dataset.path_or_name`, `cfg.dataset.split`, etc.
+
+**Phase 2: Refactor Other Example Scripts**
+
+1.  **Identify Example Scripts for Refactoring:**
+    *   Go through the `examples/` directory. Scripts that load or process datasets are candidates.
+    *   Examples:
+        *   `examples/math_example/local_eval.py`
+        *   `examples/math_example_openr1/trl_grpo_integration.py` (and other TRL examples)
+        *   `examples/folder_based_evaluation_example.py` (for its sample file loading)
+        *   Any script that currently hardcodes dataset paths or has its own `load_dataset` logic.
+
+2.  **For each identified script:**
+    *   **Introduce Hydra:** Add the `@hydra.main` decorator and necessary imports.
+    *   **Create a `conf` directory and `config.yaml` locally within the example's directory.**
+    *   **Define a `dataset` group in its local `config.yaml`:** This group will allow users to specify which pre-defined dataset config (from the global `project_root/conf/dataset/`) to use, or override parameters.
+        ```yaml
+        # e.g., examples/math_example_openr1/conf/config.yaml
+        defaults:
+          - dataset: openr1_math_220k # Assuming project_root/conf/dataset/openr1_math_220k.yaml exists
+          - _self_
+
+        # Script-specific parameters (e.g., model, training args)
+        model_name: "Qwen/Qwen2-0.5B-Instruct"
+        # ... other script params
+
+        dataset:
+          # Overrides for the openr1_math_220k default if needed
+          max_samples: 500
+        ```
+    *   **Modify the script to use `cfg.dataset`:**
+        *   Call the central dataset loader: `loaded_data = hydra.utils.instantiate(cfg.dataset)`
+        *   This `loaded_data` would be the processed dataset ready for use by the example script.
+    *   Remove old `argparse` or manual path handling for datasets.
+
+**Phase 3: Documentation & Best Practices**
+
+1.  **Update `CONTRIBUTING.md` or create a new guide:**
+    *   Explain the new dataset configuration system.
+    *   Show how to define new dataset configs in the global `project_root/conf/dataset/`.
+    *   Provide examples of how to run scripts with different dataset configurations via Hydra CLI overrides.
+2.  **Add READMEs to example directories:** Explain how to run each example using its Hydra config.
+
+**Benefits of this approach:**
+
+*   **Consistency:** All examples will use a standardized way to load and configure datasets.
+*   **Reusability:** Dataset definitions (global `conf/dataset/*.yaml`) can be reused across multiple examples.
+*   **Clarity:** Users can easily see and modify dataset configurations without digging into script code.
+*   **Flexibility:** Hydra's command-line overrides and composition make it easy to experiment with different datasets or parameters.
+*   **Centralized Logic:** The core dataset loading and preprocessing logic is maintained in one place (e.g., `reward_kit.datasets.loader`).
+
+**Diagrammatic Overview:**
+
+```mermaid
+graph TD
+    subgraph Core Reward Kit
+        A[reward_kit.datasets.loader.py] -- Defines --> B(Dataset Loading/Processing Functions);
+    end
+
+    subgraph Global Hydra Configurations
+        C[project_root/conf/dataset/base_dataset.yaml] -- Defines schema for --> D{Global Dataset Configs};
+        E[project_root/conf/dataset/gsm8k.yaml] -- Instantiates --> D;
+        F[project_root/conf/dataset/custom_jsonl.yaml] -- Instantiates --> D;
+    end
+
+    subgraph Example Scripts
+        G[examples/math_example/convert_dataset.py] -- Uses --> H(Local conf/config.yaml);
+        H -- Specifies/Overrides by referring to --> E;
+        G -- Calls --> A;
+
+        I[examples/another_example.py] -- Uses --> J(Local conf/config.yaml);
+        J -- Specifies/Overrides by referring to --> F;
+        I -- Calls --> A;
+    end
+
+    B -- Driven by --> D;
+```
+
+**Key Considerations from Discussion:**
+
+*   **Location of `conf/dataset/`:** A root-level `project_root/conf/dataset/` is preferred for global dataset definitions, making them "first-class citizens".
+*   **Dataclass Schemas vs. Pure YAML:** Using Python dataclasses (e.g., with `hydra_zen`) for config schemas is a good practice for validation and IDE support, potentially for a later refinement.
+*   **Initial Focus:** Start by creating the `reward_kit.datasets.loader` module and a couple of basic global dataset configs. Then refactor one or two example scripts to use this new system.

--- a/examples/math_example/conf/config.yaml
+++ b/examples/math_example/conf/config.yaml
@@ -1,0 +1,37 @@
+# Hydra Configuration for convert_dataset.py
+
+hydra:
+  run:
+    # Hydra's output directory, can be overridden.
+    # Default is outputs/YYYY-MM-DD/HH-MM-SS
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  job_logging:
+    root:
+      level: INFO
+  sweep: # Default sweeper config
+    dir: ./multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}
+
+
+# Parameters for the dataset source
+dataset:
+  name: "open-r1/OpenR1-Math-220k"    # Default HF dataset name
+  config_name: null                   # Optional: e.g., "main" for gsm8k, "default" for openbookqa
+  split: "train"                      # Default dataset split
+
+  # Column names in the source dataset
+  query_column: "problem"
+  solution_column_for_assistant: "solution"
+  ground_truth_answer_column: "answer"
+
+# Parameters for processing the dataset
+processing:
+  filter_by_match: false              # Enable filtering by matching solution to ground truth
+  math_type: "numeric"                # Type of math reward for filtering: "numeric", "mcq", "list"
+
+# Parameters for the output
+output:
+  # Path for the output JSONL file.
+  # If relative, it will be inside Hydra's output directory (hydra.run.dir).
+  # If absolute, it will be used as is.
+  file_path: "converted_dataset.jsonl"

--- a/examples/math_example/local_eval.py
+++ b/examples/math_example/local_eval.py
@@ -47,8 +47,6 @@ def main():
 
         # The math_reward expects the full conversation history.
         # The last message is the assistant's response to be evaluated.
-        # The original_messages can be the same as messages if no modification is needed
-        # for the reward function's internal processing.
         # The ground_truth for math_reward should be the expected answer string.
         # For this example, the dataset's assistant message is the ground truth.
         assistant_response_content = next(

--- a/examples/math_example_openr1/fireworks_regenerate.py
+++ b/examples/math_example_openr1/fireworks_regenerate.py
@@ -403,7 +403,6 @@ async def main(args):
             try:
                 result = math_reward(
                     messages=messages_for_eval,
-                    original_messages=messages_for_eval,  # Using regenerated as original for this eval
                     ground_truth=original_assistant_content,
                 )
 

--- a/examples/math_example_openr1/trl_grpo_integration.py
+++ b/examples/math_example_openr1/trl_grpo_integration.py
@@ -48,7 +48,7 @@ grpo_config = GRPOConfig(
 
 # --- Helper Functions ---
 def load_jsonl_dataset(file_path: str):
-    """Loads data from a JSONL file, expecting 'messages' and 'ground_truth_answer_from_column', and processes it for TRL."""
+    """Loads data from a JSONL file, expecting 'messages' and 'ground_truth', and processes it for TRL."""
     raw_data = load_jsonl(file_path)  # Use the new utility
     if not raw_data:
         return []  # Return empty list if loading failed or file was empty
@@ -65,7 +65,7 @@ def load_jsonl_dataset(file_path: str):
         )
 
         # For this OpenR1 example, the ground truth is specifically in this field
-        ground_truth_response = item.get("ground_truth_answer_from_column")
+        ground_truth_response = item.get("ground_truth")
 
         if user_msg_content and ground_truth_response is not None:
             processed_trl_data.append(
@@ -76,7 +76,7 @@ def load_jsonl_dataset(file_path: str):
                 }
             )
         elif user_msg_content:  # Handle cases where ground_truth might be missing
-            # logging.warning(f"Missing 'ground_truth_answer_from_column' for prompt: {user_msg_content[:50]}...") # Optional logging
+            # logging.warning(f"Missing 'ground_truth' for prompt: {user_msg_content[:50]}...") # Optional logging
             processed_trl_data.append(
                 {
                     "prompt": user_msg_content,

--- a/examples/trl_integration/grpo_example.py
+++ b/examples/trl_integration/grpo_example.py
@@ -64,7 +64,7 @@ def format_reward(
 
     Args:
         messages: List of conversation messages
-        original_messages: Original messages for context
+        ground_truth: Optional ground truth context (not used by this specific function).
         think_tag: Tag to use for reasoning (default: "<think>")
         answer_tag: Tag to use for answers (default: "<answer>")
 
@@ -409,7 +409,7 @@ def train_with_grpo_example():
     }
 
     # Configuration for rk_math_reward
-    # rk_math_reward needs 'original_messages' (ground truth) from the 'solution' column
+    # rk_math_reward's 'ground_truth' parameter will be mapped from the 'solution' column of the dataset.
     math_reward_config = {
         "func": rk_math_reward,
         "map": {


### PR DESCRIPTION
This PR includes the following changes:
- Corrects outdated dataset parameter usage (`original_message`, `ground_truth_answer_from_column`) in various example scripts, ensuring `ground_truth` is used consistently.
- Refactors `examples/math_example/convert_dataset.py` to use Hydra for configuration, with a new config file at `examples/math_example/conf/config.yaml`.
- Adds a documented plan for a broader Hydra-based dataset management system in `development/notes/hydra_dataset_refactor_plan.md`.

Affected files:
- `examples/math_example/local_eval.py`
- `examples/math_example/convert_dataset.py`
- `examples/math_example_openr1/trl_grpo_integration.py`
- `examples/trl_integration/grpo_example.py`
- `examples/math_example_openr1/fireworks_regenerate.py`
- `examples/math_example/conf/config.yaml`
- `development/notes/hydra_dataset_refactor_plan.md`