### PR TITLE
Add optional TRL extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@
 pip install reward-kit
 ```
 
+### Optional TRL Extras
+
+Install the additional dependencies required for running the TRL-based training
+examples:
+
+```bash
+pip install "reward-kit[trl]"
+```
+
 ## Getting Started
 
 The Reward Kit simplifies the creation and deployment of reward functions for evaluating AI model outputs.

--- a/docs/examples/tool_calling_example.mdx
+++ b/docs/examples/tool_calling_example.mdx
@@ -20,9 +20,9 @@ A sample `dataset.jsonl` is provided in the example directory. For tool calling 
     # From the root of the repository
     pip install -e ".[dev]"
     ```
-2.  **TRL Dependencies (for `trl_grpo_integration.py`)**:
+2.  **TRL Extras (for `trl_grpo_integration.py`)**:
     ```bash
-    pip install trl peft datasets accelerate
+    pip install "reward-kit[trl]"
     ```
 3.  **API Keys**: If using models that require API keys (e.g., Fireworks AI models for `local_eval.py` if not using a local model, or for downloading a base model for TRL), ensure necessary keys like `FIREWORKS_API_KEY` are set.
 

--- a/docs/examples/trl_integration/trl_integration_overview.mdx
+++ b/docs/examples/trl_integration/trl_integration_overview.mdx
@@ -61,10 +61,10 @@ python examples/trl_integration/minimal_deepcoder_grpo_example.py
 
 ## Prerequisites
 
-To run these examples, you generally need to install TRL and related dependencies:
+To run these examples you'll need the optional TRL dependencies:
 
 ```bash
-pip install trl peft datasets accelerate
+pip install "reward-kit[trl]"
 ```
 
 For the GRPO example, you might also need:

--- a/examples/math_example/trl_grpo_integration.py
+++ b/examples/math_example/trl_grpo_integration.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         print(
             "Please ensure PyTorch, Transformers, TRL, Datasets, PEFT, and Accelerate are installed."
         )
-        print("Example: pip install torch transformers trl datasets peft accelerate")
+        print("Example: pip install 'reward-kit[trl]' transformers")
         sys.exit(1)
 
     # Calling main() directly here will invoke Hydra's initialization process.

--- a/examples/math_with_formatting/trl_grpo_integration.py
+++ b/examples/math_with_formatting/trl_grpo_integration.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         print(
             "Please ensure PyTorch, Transformers, TRL, Datasets, PEFT, and Accelerate are installed."
         )
-        print("Example: pip install torch transformers trl datasets peft accelerate")
+        print("Example: pip install 'reward-kit[trl]' transformers")
         sys.exit(1)
 
     # Calling main() directly here will invoke Hydra's initialization process.

--- a/examples/tool_calling_example/trl_grpo_integration.py
+++ b/examples/tool_calling_example/trl_grpo_integration.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     # This print will be replaced by logger if Hydra initializes logging first
     print(
-        "Please install transformers and trl: pip install transformers trl peft bitsandbytes"
+        "Please install transformers and TRL dependencies: pip install 'reward-kit[trl]' transformers bitsandbytes"
     )
     sys.exit(1)
 
@@ -405,8 +405,6 @@ if __name__ == "__main__":
         print(
             f"Import error: {e}. Some libraries missing for Tool Calling TRL example."
         )
-        print(
-            "Install: pip install torch transformers trl datasets peft bitsandbytes accelerate"
-        )
+        print("Install: pip install 'reward-kit[trl]' transformers bitsandbytes")
         sys.exit(1)
     main()

--- a/examples/trl_integration/grpo_example.py
+++ b/examples/trl_integration/grpo_example.py
@@ -43,7 +43,7 @@ try:
     HAS_TRL = True
 except ImportError:
     print(
-        "TRL or related packages not installed. Install with: pip install trl peft datasets math-verify"
+        "TRL or related packages not installed. Install with: pip install 'reward-kit[trl]' math_verify"
     )
     HAS_TRL = False
 
@@ -309,7 +309,7 @@ def prepare_dataset_for_trl(
     """
     if not HAS_TRL:
         print(
-            "TRL or related packages not installed. Install with: pip install trl peft datasets"
+            "TRL or related packages not installed. Install with: pip install 'reward-kit[trl]'"
         )
         return None
 
@@ -388,7 +388,7 @@ def train_with_grpo_example():
     """
     if not HAS_TRL:
         print(
-            "TRL or related packages not installed. Install with: pip install trl peft datasets"
+            "TRL or related packages not installed. Install with: pip install 'reward-kit[trl]'"
         )
         return
 

--- a/examples/trl_integration/minimal_deepcoder_grpo_example.py
+++ b/examples/trl_integration/minimal_deepcoder_grpo_example.py
@@ -27,7 +27,7 @@ try:
     HAS_TRL_AND_TRANSFORMERS = True
 except ImportError as e:
     print(
-        f"TRL/Transformers/PEFT/Datasets not installed. Install with: pip install trl transformers torch peft datasets accelerate. Error: {e}"
+        f"TRL/Transformers/PEFT/Datasets not installed. Install with: pip install 'reward-kit[trl]' transformers bitsandbytes. Error: {e}"
     )
     HAS_TRL_AND_TRANSFORMERS = False
 
@@ -289,5 +289,5 @@ if __name__ == "__main__":
         main()
     else:
         print(
-            "TRL/Transformers/PEFT/Datasets not found. Please install them to run this example: pip install trl transformers torch peft datasets accelerate"
+            "TRL/Transformers/PEFT/Datasets not found. Please install them to run this example: pip install 'reward-kit[trl]' transformers bitsandbytes"
         )

--- a/examples/trl_integration/ppo_example.py
+++ b/examples/trl_integration/ppo_example.py
@@ -38,7 +38,7 @@ try:
     HAS_TRL = True
 except ImportError:
     print(
-        "TRL or related packages not installed. Install with: pip install trl datasets"
+        "TRL or related packages not installed. Install with: pip install 'reward-kit[trl]'"
     )
     HAS_TRL = False
 
@@ -179,7 +179,7 @@ def prepare_dataset_for_ppo(dataset_name, split="train", max_samples=None):
     """
     if not HAS_TRL:
         print(
-            "TRL or related packages not installed. Install with: pip install trl datasets"
+            "TRL or related packages not installed. Install with: pip install 'reward-kit[trl]'"
         )
         return None
 
@@ -214,7 +214,7 @@ def train_with_ppo_example():
     """
     if not HAS_TRL:
         print(
-            "TRL or related packages not installed. Install with: pip install trl datasets"
+            "TRL or related packages not installed. Install with: pip install 'reward-kit[trl]'"
         )
         return
 

--- a/examples/trl_integration/working_grpo_example.py
+++ b/examples/trl_integration/working_grpo_example.py
@@ -47,7 +47,7 @@ try:
     HAS_TRL = True
 except ImportError as e:
     print(f"Could not import TRL-related packages: {e}")
-    print("Install with: pip install trl peft datasets accelerate math_verify")
+    print("Install with: pip install 'reward-kit[trl]' math_verify")
     HAS_TRL = False
 
 
@@ -282,7 +282,7 @@ def run_grpo_training_example():
     """
     if not HAS_TRL:
         print(
-            "TRL or related packages not installed. Install with: pip install trl peft datasets accelerate"
+            "TRL or related packages not installed. Install with: pip install 'reward-kit[trl]'"
         )
         return
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,13 @@ setup(
             "e2b>=0.15.0",  # Added e2b for E2B environment tests
             "docker==7.1.0",
         ],
+        "trl": [
+            "torch>=1.9",
+            "trl>=0.7.0",
+            "peft>=0.7.0",
+            "transformers>=4.0.0",
+            "accelerate>=0.28.0",
+        ],
         "deepseek": [
             "difflib>=3.0.0",
         ],


### PR DESCRIPTION
## Summary
- create an optional `trl` extra in setup.py
- document how to install the extras in README and docs
- update example scripts to reference the new extras instead of raw package lists

## Testing
- `black --check setup.py examples/trl_integration/working_grpo_example.py examples/trl_integration/grpo_example.py examples/trl_integration/ppo_example.py examples/trl_integration/minimal_deepcoder_grpo_example.py examples/tool_calling_example/trl_grpo_integration.py examples/math_with_formatting/trl_grpo_integration.py examples/math_example/trl_grpo_integration.py`
- `pytest -q` *(fails: ModuleNotFoundError & other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68413239ed488333818bd53c2951b677