### PR TITLE
Add mode attribute to reward function decorator

### DIFF
--- a/reward_kit/typed_interface.py
+++ b/reward_kit/typed_interface.py
@@ -264,9 +264,10 @@ def reward_function(
                     f"Return value from function '{func.__name__}' failed Pydantic validation for mode '{mode}':\n{err}"
                 ) from None
 
-        # Set id and requirements attributes
+        # Set id, requirements, and mode attributes
         wrapper._reward_function_id = id
         wrapper._reward_function_requirements = requirements
+        wrapper._reward_function_mode = mode
 
         return cast(F, wrapper)
 

--- a/tests/test_typed_interface_rl.py
+++ b/tests/test_typed_interface_rl.py
@@ -101,8 +101,12 @@ class TestTypedInterfaceRL:
         assert result.score == 0.5
         assert result.step_outputs is not None
         assert len(result.step_outputs) == 1
-        assert result.step_outputs[0].step_index == 1  # assistant message index
-        assert result.step_outputs[0].base_reward == 0.1 * 1
+        # Type assertion to help the linter understand step_outputs is not None
+        step_outputs = result.step_outputs
+        assert step_outputs is not None
+        step_output = step_outputs[0]
+        assert step_output.step_index == 1  # assistant message index
+        assert step_output.base_reward == 0.1 * 1
 
     def test_pointwise_rl_rewards_with_pydantic_messages(self):
         """Test pointwise RL reward function with Pydantic Message objects."""


### PR DESCRIPTION
This PR adds a  attribute to the reward function decorator to store the mode parameter. It also improves type assertions in the test file for better linting support.