### PR TITLE
Use Fireworks model in GEval example

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Check the `examples` directory for complete examples:
 - `deploy_example.py`: How to deploy a reward function to Fireworks.
 - `math_example/`: Demonstrates CLI-based evaluation (`reward-kit run`) and TRL GRPO training for math problems (GSM8K dataset).
 - `apps_coding_example/`: Shows CLI-based evaluation (`reward-kit run`) for code generation tasks (APPS dataset).
- - `apps_coding_example/`: Shows CLI-based evaluation (`reward-kit run`) for code generation tasks (APPS dataset).
+- `geval_integration_example.py`: Demonstrates using a deepeval GEval metric with a Fireworks model as the LLM judge.
 
 The OpenEvals project provides a suite of evaluators that can be used directly within Reward Kit. The helper `reward_kit.integrations.openeval.adapt` converts any OpenEvals evaluator into a reward function returning an `EvaluateResult`.
 

--- a/docs/examples/examples_overview.mdx
+++ b/docs/examples/examples_overview.mdx
@@ -38,6 +38,10 @@ Many examples use [Hydra for configuration](./../developer_guide/hydra_configura
     *   Shows how to integrate reward-kit functions with the TRL library.
     *   [View Documentation](../integrations/trl_integration_overview.mdx)
 
+*   **GEval Integration Example**:
+    *   Uses a deepeval GEval metric with a Fireworks model as the LLM judge within Reward Kit.
+    *   [View Documentation](./geval_integration/geval_integration_example.mdx)
+
 *Note: The `examples/metrics/` and `examples/test_tasks/` directories in the root `examples/` folder contain supporting resources and are not standalone documented examples here.*
 
 ## General Guides for Examples

--- a/docs/examples/geval_integration/geval_integration_example.mdx
+++ b/docs/examples/geval_integration/geval_integration_example.mdx
@@ -1,0 +1,34 @@
+# Deepeval GEval Integration Example
+
+This guide demonstrates how to use a [deepeval](https://github.com/confident-ai/deepeval) `GEval` metric with Reward Kit. GEval metrics employ an LLM as a judge to score model outputs based on custom criteria. The example configures the judge to be the Fireworks model `accounts/fireworks/models/qwen3-235b-a22b`.
+
+## Overview
+
+The script [`geval_integration_example.py`](../../examples/geval_integration_example.py) shows how to:
+
+1. Construct a `GEval` metric defining the evaluation criteria.
+2. Adapt that metric into a Reward Kit reward function using `adapt_metric`.
+3. Evaluate a short conversation (in this case a simple translation) and print the resulting score and reason.
+
+## Running the Example
+
+## Setup
+
+1. Install Reward Kit with the deepeval extras:
+
+```bash
+pip install "reward-kit[deepeval]"
+```
+
+2. Ensure your Fireworks API key is available as the `FIREWORKS_API_KEY` environment variable. The example script sets up the OpenAI-compatible base URL automatically.
+3. Execute the script from the repository root:
+
+```bash
+python examples/geval_integration_example.py
+```
+
+You should see a numeric score along with an optional reason returned by the GEval metric.
+
+## When to Use GEval
+
+GEval metrics are useful whenever you need an automated judge to assess qualities such as correctness, helpfulness or relevance. By combining `adapt_metric` with GEval you can seamlessly incorporate these evaluations into Reward Kit workflows.

--- a/examples/geval_integration_example.py
+++ b/examples/geval_integration_example.py
@@ -1,0 +1,57 @@
+"""GEval integration example using Reward Kit.
+
+This script demonstrates how to adapt a deepeval GEval metric into a reward
+function for LLM-as-a-judge evaluation. It configures the GEval metric to use
+Fireworks' ``accounts/fireworks/models/qwen3-235b-a22b`` model as the judge.
+Make sure the ``FIREWORKS_API_KEY`` environment variable is set before running
+the script.
+"""
+
+import os
+
+from deepeval.metrics import GEval
+from deepeval.models import GPTModel
+from deepeval.test_case import LLMTestCaseParams
+
+from reward_kit.integrations.deepeval import adapt_metric
+
+
+def main() -> None:
+    """Run a simple GEval evaluation."""
+    api_key = os.getenv("FIREWORKS_API_KEY")
+    if not api_key:
+        raise RuntimeError("FIREWORKS_API_KEY environment variable must be set.")
+
+    fireworks_llm = GPTModel(
+        model="accounts/fireworks/models/qwen3-235b-a22b",
+        _openai_api_key=api_key,
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    correctness_metric = GEval(
+        name="Correctness",
+        criteria="Determine whether the answer is factually correct",
+        evaluation_params=[
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ],
+        model=fireworks_llm,
+    )
+
+    reward_fn = adapt_metric(correctness_metric)
+
+    messages = [
+        {"role": "user", "content": "Translate 'Hello, world!' to Spanish."},
+        {"role": "assistant", "content": "Hola, mundo!"},
+    ]
+
+    result = reward_fn(messages=messages, ground_truth="Hola, mundo!")
+
+    print(f"Score: {result.score}")
+    if result.reason:
+        print(f"Reason: {result.reason}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update GEval integration example to use Fireworks `qwen3-235b-a22b`
- document Fireworks setup for the GEval example
- clarify Fireworks usage in examples overview and README

## Testing
- `pre-commit run --files examples/geval_integration_example.py README.md docs/examples/geval_integration/geval_integration_example.mdx docs/examples/examples_overview.mdx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a75331608333b6d57520e7378698