### PR TITLE
fix: broken homepage link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     author_email="info@fireworks.ai",
     description="A Python library for defining, testing, and using reward functions",
     long_description="A library for defining, testing, and deploying reward functions",
-    url="https://github.com/fireworks-ai/reward-kit",
+    url="https://github.com/fw-ai-external/reward-kit",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
## Description

When I was trying to find the source code for this library, I ended up on the pypi page but had a bit of trouble finding the github repo (as far as I could tell, it wasn't linked from the fireworks documentation).

The "homepage" link on [reward-kit's pypi
page](https://pypi.org/project/reward-kit/) points at a broken link: https://github.com/fireworks-ai/reward-kit

Tiny tweak to point at the actual repo: https://github.com/fw-ai-external/reward-kit

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring/Code cleanup
- [ ] Build/CI/CD related changes
- [x] Other (please describe): documentation

## Checklist:

- [ ] My code follows the style guidelines of this project (ran `black .`, `isort .`, `flake8 .`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

